### PR TITLE
Using enum's to represent currency

### DIFF
--- a/examples/initialize_transaction.rs
+++ b/examples/initialize_transaction.rs
@@ -2,6 +2,7 @@ use chapa_rust::{
     client::ChapaClient,
     config::ChapaConfigBuilder,
     models::payment::{Customization, InitializeOptions},
+    models::bank::Currency
 };
 #[tokio::main]
 async fn main() {
@@ -14,7 +15,7 @@ async fn main() {
     let tx_ref = String::from("mail_order_injera");
     let test_transaction = InitializeOptions {
         amount: "150".to_string(),
-        currency: String::from("USD"),
+        currency: Currency::USD,
         email: Some(String::from("john_doe@gmail.com")),
         first_name: Some(String::from("John")),
         last_name: Some(String::from("Doe")),

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,6 +28,7 @@ use crate::{
     error::{ChapaError, Result},
     models::{
         payment::InitializeOptions,
+        bank::Currency,
         response::{GetBanksResponse, InitializeResponse, VerifyResponse},
     },
 };
@@ -143,13 +144,13 @@ impl ChapaClient {
     /// ```rust,no_run
     /// #[tokio::main]
     /// async fn main() {
-    /// use chapa_rust::{client::ChapaClient, config::ChapaConfigBuilder, models::payment::InitializeOptions};
+    /// use chapa_rust::{client::ChapaClient, config::ChapaConfigBuilder, models::payment::InitializeOptions, models::bank::Currency};
     /// dotenvy::dotenv().ok();
     /// let config = ChapaConfigBuilder::new().build().unwrap();
     /// let mut client = ChapaClient::from_config(config).unwrap();
     /// let transaction = InitializeOptions {
     ///         amount: "100".to_string(),
-    ///         currency: "ETB".to_string(),
+    ///         currency: Currency::ETB,
     ///         email: Some("customer@gmail.com".to_string()),
     ///         first_name: Some("John".to_string()),
     ///         last_name: Some("Doe".to_string()),
@@ -345,7 +346,7 @@ mod tests {
 
         let transaction_success = InitializeOptions {
             amount: "100".to_string(),
-            currency: "ETB".to_string(),
+            currency: Currency::ETB,
             email: Some("customer@gmail.com".to_string()),
             first_name: Some("John".to_string()),
             last_name: Some("Doe".to_string()),

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,7 +28,6 @@ use crate::{
     error::{ChapaError, Result},
     models::{
         payment::InitializeOptions,
-        bank::Currency,
         response::{GetBanksResponse, InitializeResponse, VerifyResponse},
     },
 };
@@ -346,7 +345,7 @@ mod tests {
 
         let transaction_success = InitializeOptions {
             amount: "100".to_string(),
-            currency: Currency::ETB,
+            currency: crate::models::bank::Currency::ETB,
             email: Some("customer@gmail.com".to_string()),
             first_name: Some("John".to_string()),
             last_name: Some("Doe".to_string()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 //! ```
 //! use chapa_rust::client::ChapaClient;
 //! use chapa_rust::models::payment::InitializeOptions;
+//! use chapa_rust::models::bank::Currency;
 //!
 //! #[tokio::main]
 //! async fn main() {
@@ -32,7 +33,7 @@
 //!
 //!     let req = InitializeOptions {
 //!         amount: "100".to_string(),
-//!         currency: "ETB".to_string(),
+//!         currency: Currency::ETB,
 //!         email: Some("customer@example.com".to_string()),
 //!         first_name: Some("John".to_string()),
 //!         last_name: Some("Doe".to_string()),

--- a/src/models/bank.rs
+++ b/src/models/bank.rs
@@ -2,6 +2,7 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::default::Default;
 
 /// Represents a single bank entry from Chapa’s bank list.
 #[derive(Debug, Serialize, Deserialize)]
@@ -35,4 +36,10 @@ pub enum Currency {
     ETB,
     /// United States Dollar
     USD,
+}
+
+impl Default for Currency {
+    fn default() -> Self {
+        Self::ETB
+    }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -7,11 +7,12 @@
 //! ## Example
 //! ```rust,no_run
 //! use chapa_rust::models::payment::InitializeOptions;
+//! use chapa_rust::models::bank::Currency;
 //!
 //! // Create a transaction
 //! let tx = InitializeOptions {
 //!     amount: "100".to_string(),
-//!     currency: "ETB".to_string(),
+//!     currency: Currency::ETB,
 //!     email: Some("user@example.com".to_string()),
 //!     first_name: Some("John".to_string()),
 //!     last_name: Some("Doe".to_string()),

--- a/src/models/payment.rs
+++ b/src/models/payment.rs
@@ -2,6 +2,7 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use crate::models::bank::Currency;
 
 // TODO: check the type of `amount` field has some inconsistency in the docs, sometimes it's string sometimes number
 // ------------------------------------- Initialize Payment ---------------------------------------------
@@ -18,7 +19,7 @@ pub struct InitializeOptions {
     /// The phone number of the customer.
     pub phone_number: Option<String>,
     /// The currency for the transaction (e.g., "ETB", "USD").
-    pub currency: String,
+    pub currency: Currency,
     /// The amount to be charged in the transaction.
     pub amount: String,
     /// A unique reference for the transaction.
@@ -89,7 +90,7 @@ pub struct VerifyData {
     /// The email address of the customer.
     pub email: Option<String>,
     /// The currency for the transaction (e.g., "ETB", "USD").
-    pub currency: Option<String>,
+    pub currency: Option<Currency>,
     /// The amount to be charged in the transaction.
     pub amount: f64,
     /// The charge for the transaction.

--- a/src/models/transaction.rs
+++ b/src/models/transaction.rs
@@ -1,4 +1,5 @@
 //! Models related to get_transactions API responses.
+use crate::models::bank::Currency;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -49,7 +50,7 @@ pub struct Transaction {
     /// The date and time when the transaction was created.
     pub created_at: DateTime<Utc>,
     /// The currency in which the transaction was made.
-    pub currency: String,
+    pub currency: Currency,
     /// The amount of money that is involved in the transaction.
     pub amount: String,
     /// The charge applied to the transaction.

--- a/src/models/transfer.rs
+++ b/src/models/transfer.rs
@@ -1,5 +1,6 @@
 //! Models related to bank transfers.
 
+use crate::models::bank::Currency;
 use serde::{Deserialize, Serialize};
 
 /// Represents the options required to initiate a bank transfer.
@@ -12,7 +13,7 @@ pub struct TransferOptions {
     /// The amount to be transferred.
     pub amount: String,
     /// The currency in which the transfer will be made.
-    pub currency: String,
+    pub currency: Currency,
     /// A unique reference for the transfer.
     pub reference: String,
     /// The bank code of the recipient's bank.


### PR DESCRIPTION
# Pull Request

Short description
- What: Changed the currency fields on different structs to Currency enum.
- Why: Using enums makes it clear instead of strings in this case.
- How: Changed the fields to use Currency enum from the bank module.

Checklist
- [ &#9745;] PR targets the correct branch <!-- i.e., develop -->
- [&#9745; ] Code compiles without errors
- [ ] Tests added/updated or not applicable
- [ ] CI passes
- [ ] Docs/CHANGELOG updated if needed
- [ &#9745;] PR follows Conventional Commits (feat:, fix:, docs:, etc.)

Related
- <!-- Fixes # (optional) -->

Testing
- Run: `make check`
- Notes: add any manual steps if required