### PR TITLE
Implementation of missing modules/endpoints 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,18 +3,21 @@ name = "chapa-rust"
 version = "0.1.0"
 edition = "2024"
 description = "Chapa SDK for Rust to integrate Chapa payment gateway into your Rust applications."
-authors = []                                                                                       # TODO: Fill it. 
+
+authors = [] # TODO: Fill it. 
+
 license = "MIT"
+
 repository = "https://github.com/Chapa-Et/chapa-rust"
-# homepage = "https://github.com/Chapa-Et/chapa-rust" # Link to the project homepage
-# documentation = "https://docs.rs/chapa-rust" # Link to the documentation
+
+homepage = "https://developer.chapa.co/"
+
+# documentation = "https://docs.rs/chapa-rust" # Not realeased yet
+
 readme = "README.md"
-keywords = [
-  "Chapa",
-  "rust-sdk",
-  "payment",
-  "gateway",
-] # Tags to help users find your crate
+
+keywords = ["chapa", "rust-sdk", "payment", "gateway"]
+
 categories = [
   "api-bindings",
   "asynchronous",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,19 +10,22 @@ repository = "https://github.com/Chapa-Et/chapa-rust"
 # documentation = "https://docs.rs/chapa-rust" # Link to the documentation
 readme = "README.md"
 keywords = [
-    "Chapa",
-    "rust-sdk",
-    "payment",
-    "gateway",
+  "Chapa",
+  "rust-sdk",
+  "payment",
+  "gateway",
 ] # Tags to help users find your crate
 categories = [
-    "api-bindings",
-    "asynchronous",
-    "web-programming::http-client",
-    "finance",
-    "development-tools::api",
+  "api-bindings",
+  "asynchronous",
+  "web-programming::http-client",
+  "finance",
+  "development-tools::api",
 ]
 
+[[test]]
+name = "tests"
+path = "tests/mod.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2024"
 description = "Chapa SDK for Rust to integrate Chapa payment gateway into your Rust applications."
 
 authors = [
-  "YabetsZ <yabetszekaryas07@gmail.com>",
   "Abenezer Haymanot <@abeni-csa> [abenzerhaymanot@gmail.com]",
+  "YabetsZ  <@YabetsZ> [yabetszekaryas07@gmail.com]",
 ]
 
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 edition = "2024"
 description = "Chapa SDK for Rust to integrate Chapa payment gateway into your Rust applications."
 
-authors = [] # TODO: Fill it. 
+authors = [
+  "YabetsZ <yabetszekaryas07@gmail.com>",
+  "Abenezer Haymanot <@abeni-csa> [abenzerhaymanot@gmail.com]",
+]
 
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,10 @@ Under the hood, this is a POST request to the Chapa API. It also does the work o
 use chapa_rust::{
     client::ChapaClient,
     config::ChapaConfigBuilder,
-    models::payment::{Customization, InitializeOptions},
+    models::{
+        bank::Currency,
+        payment::{Customization, InitializeOptions},
+    },
 };
 #[tokio::main]
 async fn main() {
@@ -136,7 +139,7 @@ async fn main() {
     let tx_ref = String::from("mail_order_injera");
     let test_transaction = InitializeOptions {
         amount: "150".to_string(),
-        currency: String::from("USD"),
+        currency: Currency::USD,
         email: Some(String::from("john_doe@gmail.com")),
         first_name: Some(String::from("John")),
         last_name: Some(String::from("Doe")),

--- a/examples/bulk_transfer.rs
+++ b/examples/bulk_transfer.rs
@@ -12,17 +12,20 @@ async fn main() {
         currency: Currency::ETB,
         bulk_data: vec![
             InitateTransferOptions {
-                account_name: "Israel Goytom".to_string(),
+                account_name: Some("Israel Goytom".to_string()),
                 account_number: "09xxxxxxxx".to_string(),
+
                 amount: "100".to_string(),
-                reference: "b1111124".to_string(),
+                currency: Some(Currency::ETB),
+                reference: Some("b1111124".to_string()),
                 bank_code: 128,
             },
             InitateTransferOptions {
-                account_name: "Yesehrur Goytom".to_string(),
+                account_name: Some("Yesehrur Goytom".to_string()),
                 account_number: "09xxxxxxxx".to_string(),
                 amount: "120".to_string(),
-                reference: "b1111124".to_string(),
+                currency: Some(Currency::ETB),
+                reference: Some("b1111124".to_string()),
                 bank_code: 128,
             },
         ],

--- a/examples/bulk_transfer.rs
+++ b/examples/bulk_transfer.rs
@@ -1,0 +1,36 @@
+#[tokio::main]
+async fn main() {
+    use chapa_rust::client::ChapaClient;
+    use chapa_rust::config::ChapaConfigBuilder;
+    use chapa_rust::models::transfer::BulkTransferOptions;
+    use chapa_rust::models::{bank::Currency, transfer::InitateTransferOptions};
+    dotenvy::dotenv().ok();
+    let config = ChapaConfigBuilder::new().build().unwrap();
+    let client = ChapaClient::from_config(config).unwrap();
+    let options = BulkTransferOptions {
+        title: "This Month Salary!".to_string(),
+        currency: Currency::ETB,
+        bulk_data: vec![
+            InitateTransferOptions {
+                account_name: "Israel Goytom".to_string(),
+                account_number: "09xxxxxxxx".to_string(),
+                amount: "100".to_string(),
+                reference: "b1111124".to_string(),
+                bank_code: 128,
+            },
+            InitateTransferOptions {
+                account_name: "Yesehrur Goytom".to_string(),
+                account_number: "09xxxxxxxx".to_string(),
+                amount: "120".to_string(),
+                reference: "b1111124".to_string(),
+                bank_code: 128,
+            },
+        ],
+    };
+
+    let result = client.bulk_transfer(options).await;
+    match result {
+        Ok(banks) => println!("{:#?}", banks),
+        Err(e) => eprintln!("{:#?}", e),
+    }
+}

--- a/examples/initialize_transaction.rs
+++ b/examples/initialize_transaction.rs
@@ -1,7 +1,10 @@
 use chapa_rust::{
     client::ChapaClient,
     config::ChapaConfigBuilder,
-    models::payment::{Customization, InitializeOptions},
+    models::{
+        bank::Currency,
+        payment::{Customization, InitializeOptions},
+    },
 };
 #[tokio::main]
 async fn main() {
@@ -14,7 +17,7 @@ async fn main() {
     let tx_ref = String::from("mail_order_injera");
     let test_transaction = InitializeOptions {
         amount: "150".to_string(),
-        currency: String::from("USD"),
+        currency: Currency::USD,
         email: Some(String::from("john_doe@gmail.com")),
         first_name: Some(String::from("John")),
         last_name: Some(String::from("Doe")),

--- a/examples/swap_balace.rs
+++ b/examples/swap_balace.rs
@@ -1,0 +1,21 @@
+#[tokio::main]
+async fn main() {
+    use chapa_rust::{
+        client::ChapaClient,
+        config::ChapaConfigBuilder,
+        models::{balances::SwapOptions, bank::Currency},
+    };
+    dotenvy::dotenv().ok();
+    let config = ChapaConfigBuilder::new().build().unwrap();
+    let client = ChapaClient::from_config(config).unwrap();
+    let option = SwapOptions {
+        amount: 100,
+        from: Currency::USD,
+        to: Currency::ETB,
+    };
+    let swap = client.swap_currency(option).await;
+    match swap {
+        Ok(swap) => println!("{:#?}", swap),
+        Err(e) => eprintln!("{:#?}", e),
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -29,6 +29,7 @@ use crate::{
     models::{
         payment::InitializeOptions,
         response::{GetBanksResponse, InitializeResponse, VerifyResponse},
+        transaction::CancelTransactionResponse,
     },
 };
 
@@ -205,6 +206,33 @@ impl ChapaClient {
             .make_request::<VerifyResponse, ()>(endpoint.as_str(), "GET", None)
             .await?;
 
+        Ok(response)
+    }
+
+    /// Cancels an active transaction, expiring its checkout link.
+    /// This Functions `PUT` to request `transaction/cancel/{tx_ref}`
+    /// and returns the transaction’s cancelation details.
+    ///
+    /// # Arguments
+    /// * `tx_ref` - Your transaction reference used when initializing the payment.
+    ///
+    /// # Example
+    /// ```
+    /// #[tokio::main]
+    /// async fn main() {
+    /// use chapa_rust::{client::ChapaClient, config::ChapaConfigBuilder};
+    /// dotenvy::dotenv().ok();
+    /// let config = ChapaConfigBuilder::new().build().unwrap();
+    /// let mut client = ChapaClient::from_config(config).unwrap();
+    /// let tx_ref = "tx-456-sdf";
+    /// let response = client.cancel_transaction(tx_ref).await.unwrap();
+    /// }
+    /// ```
+    pub async fn cancel_transaction(&self, tx_ref: &str) -> Result<CancelTransactionResponse> {
+        let endpoint = format!("transaction/cancel/{}", tx_ref);
+        let response = self
+            .make_request::<CancelTransactionResponse, ()>(endpoint.as_str(), "PUT", None)
+            .await?;
         Ok(response)
     }
 }
@@ -461,5 +489,56 @@ mod tests {
 
         success.assert_async().await;
         failure.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_cancel_transaction_success() {
+        let mut server = mockito::Server::new_async().await;
+        let tx_ref = "tx-456-sdf";
+
+        let success_mock = server
+            .mock("PUT", format!("/v1/transaction/cancel/{}", tx_ref).as_str())
+            .match_header(
+                "authorization",
+                Matcher::Regex(r#"^Bearer .+$"#.to_string()),
+            )
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::to_string(&serde_json::json!(
+                    {
+                        "message": "Checkout link expired successfully",
+                        "status": "success",
+                        "data": {
+                            "tx_ref": "tx-456-sdf",
+                            "amount": 5,
+                            "currency": "ETB",
+                            "created_at": "2025-10-22T09:10:03.000000Z",
+                            "updated_at": "2025-10-22T09:10:21.000000Z"
+                        }
+                    }
+                ))
+                .unwrap(),
+            )
+            .create_async()
+            .await;
+
+        let config = ChapaConfigBuilder::new()
+            .base_url(server.url())
+            .api_key("CHASECK-xxxxxxxxxxxxxxxx")
+            .build()
+            .unwrap();
+        let client = ChapaClient::from_config(config).unwrap();
+        let response = client.cancel_transaction(tx_ref).await.unwrap();
+        assert_eq!(response.status, "success");
+        assert_eq!(response.message, "Checkout link expired successfully");
+        assert!(response.data.is_some());
+
+        let data = response.data.unwrap();
+        assert_eq!(data.tx_ref, tx_ref);
+        assert_eq!(data.amount, 5.0);
+        assert_eq!(data.currency.as_str(), "ETB");
+
+        success_mock.assert_async().await;
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -565,7 +565,7 @@ impl ChapaClient {
     /// specific currency by appending the currency code to the endpoint
     /// useful for checking available funds before initiating transfers or for reconciliation purposes
     ///
-    /// This function sends a `GET` request to `/balances/{USD||ETB}`
+    /// This function sends a `GET` request to `/balances/{usd||etb}`
     ///  filter balance information for a specific currency by appending the currency code to the endpoint
     /// The response contains current account balance information from Chapa.
     ///

--- a/src/client.rs
+++ b/src/client.rs
@@ -541,4 +541,42 @@ mod tests {
 
         success_mock.assert_async().await;
     }
+
+    #[tokio::test]
+    async fn test_cancel_transaction_already_expired() {
+        let mut server = mockito::Server::new_async().await;
+        let tx_ref = "already-expired-ref";
+        let failure_mock = server
+            .mock("PUT", format!("/v1/transaction/cancel/{}", tx_ref).as_str())
+            .match_header(
+                "authorization",
+                Matcher::Regex(r#"^Bearer .+$"#.to_string()),
+            )
+            .with_status(200)
+            .match_header("content-type", "application/json")
+            .with_body(
+                serde_json::to_string(&serde_json::json!({
+                    "message": "Payment link already expired",
+                    "status": "failed",
+                    "data": null
+                }))
+                .unwrap(),
+            )
+            .create_async()
+            .await;
+
+        let config = ChapaConfigBuilder::new()
+            .base_url(server.url())
+            .api_key("CHASECK-xxxxxxxxxxxxxxxx")
+            .build()
+            .unwrap();
+        let client = ChapaClient::from_config(config).unwrap();
+
+        let response = client.cancel_transaction(tx_ref).await.unwrap();
+        assert_eq!(response.status, "failed");
+        assert_eq!(response.message, "Payment link already expired");
+        assert!(response.data.is_none());
+
+        failure_mock.assert_async().await;
+    }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -27,10 +27,13 @@ use crate::{
     config::{ChapaConfig, ChapaConfigBuilder},
     error::{ChapaError, Result},
     models::{
+        balances::SwapOptions,
+        bank::Currency,
         payment::{CreateSubaccountOptions, InitializeOptions},
         response::{
             BulkTransferResponse, GetAllTransactionResponse, GetAllTransfersResponse,
-            GetBanksResponse, InitializeResponse, SubaccountResponse, TransactionEventsResponse,
+            GetBalanceResponse, GetBanksResponse, GetSingleCurrencyBalanceResponse,
+            GetSwapResponse, InitializeResponse, SubaccountResponse, TransactionEventsResponse,
             TransferResponse, VerifyResponse,
         },
         transaction::CancelTransactionResponse,
@@ -519,5 +522,133 @@ impl ChapaClient {
             )
             .await?;
         Ok(respose)
+    }
+
+    /// Gets balances for all currencies.
+    ///
+    /// This balance API allows you to retrieve your current account balance information from Chapa
+    /// useful for checking available funds before initiating transfers or for reconciliation purposes
+    ///
+    /// This function sends a `GET` request to `/balances`
+    /// The response contains current account balance information from Chapa.
+    ///
+    /// # Example
+    /// ```
+    /// #[tokio::main]
+    /// async fn main() {
+    /// use chapa_rust::client::ChapaClient;
+    /// use chapa_rust::config::ChapaConfigBuilder;
+    /// dotenvy::dotenv().ok();
+    /// let config = ChapaConfigBuilder::new().build().unwrap();
+    /// let mut client = ChapaClient::from_config(config).unwrap();
+    /// let  get_balances= client.get_balances().await;
+    ///     match get_balances{
+    ///         Ok(balances ) => println!("{:#?}", balances),
+    ///         Err(e) => eprintln!("{:#?}", e),
+    ///     }
+    /// }
+    /// ```
+    /// # Errors
+    /// Returns an error if the network request fails or if the response
+    /// cannot be deserialized.
+    pub async fn get_balances(&self) -> Result<GetBalanceResponse> {
+        let response = self
+            .make_request::<GetBalanceResponse, ()>("balances", "GET", RequestBody::None)
+            .await?;
+
+        Ok(response)
+    }
+
+    /// Gets balances by currencies.
+    ///
+    /// This balance by filter API allows you to retrieve balance information for a
+    /// specific currency by appending the currency code to the endpoint
+    /// useful for checking available funds before initiating transfers or for reconciliation purposes
+    ///
+    /// This function sends a `GET` request to `/balances/{USD||ETB}`
+    ///  filter balance information for a specific currency by appending the currency code to the endpoint
+    /// The response contains current account balance information from Chapa.
+    ///
+    /// # Example
+    /// ```
+    /// #[tokio::main]
+    /// async fn main() {
+    ///    use chapa_rust::client::ChapaClient;
+    ///    use chapa_rust::config::ChapaConfigBuilder;
+    ///    dotenvy::dotenv().ok();
+    ///    let config = ChapaConfigBuilder::new().build().unwrap();
+    ///    let mut client = ChapaClient::from_config(config).unwrap();
+    ///    let  get_balances= client.get_balances().await;
+    ///        match result {
+    ///            Ok(balances ) => println!("{:#?}", balances),
+    ///            Err(e) => eprintln!("{:#?}", e),
+    ///        }
+    /// }
+    /// ```
+    /// # Errors
+    /// Returns an error if the network request fails or if the response
+    /// cannot be deserialized.
+    pub async fn get_balance_by_currency(
+        &self,
+        currency: Currency,
+    ) -> Result<GetSingleCurrencyBalanceResponse> {
+        let endpoint = format!("balances/{}", currency);
+        let response = self
+            .make_request::<GetSingleCurrencyBalanceResponse, ()>(
+                endpoint.to_lowercase().as_str(),
+                "GET",
+                RequestBody::None,
+            )
+            .await?;
+
+        Ok(response)
+    }
+
+    /// Swap API for converting USD to ETB
+    ///
+    /// ## Important Notes
+    /// - The minimum amount for conversion is 1 USD
+    /// - Current exchange rate is applied at the time of the swap
+    /// - Swaps are processed immediately and cannot be reversed
+    /// - The maximum allowed amount for swap is $10,000
+    /// - The exchanged amount will be added to the business ETB balance
+    ///
+    /// # Example
+    /// ```
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     use chapa_rust::{
+    ///         client::ChapaClient,
+    ///         config::ChapaConfigBuilder,
+    ///         models::{balances::SwapOptions, bank::Currency},
+    ///     };
+    ///     dotenvy::dotenv().ok();
+    ///     let config = ChapaConfigBuilder::new().build().unwrap();
+    ///     let mut client = ChapaClient::from_config(config).unwrap();
+    ///     let option = SwapOptions {
+    ///         amount: 100.0,
+    ///         from: Currency::USD,
+    ///         to: Currency::ETB,
+    ///     };
+    ///     let swap = client.swap_currency(option).await;
+    ///     match swap {
+    ///         Ok(swap) => println!("{:#?}", swap),
+    ///         Err(e) => eprintln!("{:#?}", e),
+    ///     }
+    /// }
+    /// ```
+    /// # Errors
+    /// Returns an error if the network request fails or if the response
+    /// cannot be deserialized.
+    pub async fn swap_currency(&self, options: SwapOptions) -> Result<GetSwapResponse> {
+        let response = self
+            .make_request::<GetSwapResponse, SwapOptions>(
+                "swap",
+                "POST",
+                RequestBody::Json(options),
+            )
+            .await?;
+
+        Ok(response)
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -29,10 +29,11 @@ use crate::{
     models::{
         payment::{CreateSubaccountOptions, InitializeOptions},
         response::{
-            GetBanksResponse, GetTransactionsResponse, InitializeResponse, SubaccountResponse,
-            TransactionEventsResponse, VerifyResponse,
+            BulkTransferResponse, GetBanksResponse, GetTransactionsResponse, InitializeResponse,
+            SubaccountResponse, TransactionEventsResponse, TransferResponse, VerifyResponse,
         },
         transaction::CancelTransactionResponse,
+        transfer::{BulkTransferOptions, InitateTransferOptions},
     },
 };
 
@@ -48,6 +49,15 @@ pub struct ChapaClient {
     config: ChapaConfig,
 }
 
+/// Enum for representing different body formats.
+pub enum RequestBody<T> {
+    /// In case of No Body Contete like (())
+    None,
+    /// Representaion of Json body type
+    Json(T),
+    /// serializes as application/x-www-form-urlencoded
+    Form(T),
+}
 impl ChapaClient {
     /// Creates a new ChapaClient with the provided secret key.
     pub fn new(secret_key: impl Into<String>) -> Result<Self> {
@@ -82,7 +92,12 @@ impl ChapaClient {
     /// Helper function to make a generic GET or POST request to the Chapa API.
     /// # Errors
     /// Returns an error if the request fails or the response cannot be deserialized.
-    async fn make_request<T, K>(&self, endpoint: &str, method: &str, body: Option<K>) -> Result<T>
+    async fn make_request<T, K>(
+        &self,
+        endpoint: &str,
+        method: &str,
+        body: RequestBody<K>,
+    ) -> Result<T>
     where
         T: serde::de::DeserializeOwned,
         K: serde::Serialize,
@@ -96,9 +111,12 @@ impl ChapaClient {
             .map_err(|e| ChapaError::InvalidHttpMethod(format!("{}: {}", method, e)))?;
 
         let mut request = self.http.request(method, url);
-        if let Some(b) = body {
-            request = request.json(&b);
-        }
+        request = match body {
+            RequestBody::None => request,
+            RequestBody::Json(data) => request.json(&data),
+            RequestBody::Form(data) => request.form(&data),
+        };
+
         Ok(request
             .bearer_auth(&self.config.api_key)
             .headers(headers)
@@ -129,7 +147,7 @@ impl ChapaClient {
     /// cannot be deserialized.
     pub async fn get_banks(&mut self) -> Result<GetBanksResponse> {
         let response = self
-            .make_request::<GetBanksResponse, ()>("banks", "GET", None)
+            .make_request::<GetBanksResponse, ()>("banks", "GET", RequestBody::None)
             .await?;
 
         Ok(response)
@@ -173,7 +191,7 @@ impl ChapaClient {
             .make_request::<InitializeResponse, InitializeOptions>(
                 "transaction/initialize",
                 "POST",
-                Some(transaction),
+                RequestBody::Json(transaction),
             )
             .await?;
 
@@ -206,7 +224,7 @@ impl ChapaClient {
         let endpoint = format!("transaction/verify/{}", tx_ref);
 
         let response = self
-            .make_request::<VerifyResponse, ()>(endpoint.as_str(), "GET", None)
+            .make_request::<VerifyResponse, ()>(endpoint.as_str(), "GET", RequestBody::None)
             .await?;
 
         Ok(response)
@@ -234,7 +252,11 @@ impl ChapaClient {
     pub async fn cancel_transaction(&self, tx_ref: &str) -> Result<CancelTransactionResponse> {
         let endpoint = format!("transaction/cancel/{}", tx_ref);
         let response = self
-            .make_request::<CancelTransactionResponse, ()>(endpoint.as_str(), "PUT", None)
+            .make_request::<CancelTransactionResponse, ()>(
+                endpoint.as_str(),
+                "PUT",
+                RequestBody::None,
+            )
             .await?;
         Ok(response)
     }
@@ -262,14 +284,36 @@ impl ChapaClient {
     pub async fn get_transaction_events(&self, ref_id: &str) -> Result<TransactionEventsResponse> {
         let endpoint = format!("transaction/events/{}", ref_id);
         let response = self
-            .make_request::<TransactionEventsResponse, ()>(endpoint.as_str(), "GET", None)
+            .make_request::<TransactionEventsResponse, ()>(
+                endpoint.as_str(),
+                "GET",
+                RequestBody::None,
+            )
             .await?;
         Ok(response)
     }
     /// Retrieves a list of all transactions
+    ///
+    /// This function makes a `GET` request to the `/transactions` endpoint and
+    /// deserializes the JSON response into a [`GetTransactionsResponse`] struct.
+    /// # Example
+    /// ```
+    /// #[tokio::main]
+    /// async fn main() {
+    ///   use chapa_rust::client::ChapaClient;
+    ///   use chapa_rust::config::ChapaConfigBuilder;
+    ///   dotenvy::dotenv().ok();
+    ///   let config = ChapaConfigBuilder::new().build().unwrap();
+    ///   let mut client = ChapaClient::from_config(config).unwrap();
+    ///   let banks = client.get_all_transactions().await.unwrap();
+    /// }
+    /// ```
+    /// # Errors
+    /// Returns an error if the network request fails or if the response
+    /// cannot be deserialized.
     pub async fn get_all_transactions(&self) -> Result<GetTransactionsResponse> {
         let respose = self
-            .make_request::<GetTransactionsResponse, ()>("transactions", "GET", None)
+            .make_request::<GetTransactionsResponse, ()>("transactions", "GET", RequestBody::None)
             .await?;
         Ok(respose)
     }
@@ -312,9 +356,156 @@ impl ChapaClient {
             .make_request::<SubaccountResponse, CreateSubaccountOptions>(
                 "subaccount",
                 "POST",
-                Some(subaccount),
+                RequestBody::Json(subaccount),
             )
             .await?;
         Ok(response)
+    }
+
+    /// Initiates a single transfer.
+    pub async fn initiate_transfer(
+        &self,
+        options: InitateTransferOptions,
+    ) -> Result<TransferResponse> {
+        let response = self
+            .make_request::<TransferResponse, InitateTransferOptions>(
+                "transfers",
+                "POST",
+                RequestBody::Json(options),
+            )
+            .await?;
+        Ok(response)
+    }
+
+    /// Verifies a transfer by its transaction reference.
+    pub async fn verify_transfer(&self, tx_ref: &str) -> Result<TransferResponse> {
+        let endpoint = format!("transfers/verify/{}", tx_ref);
+        let response = self
+            .make_request::<TransferResponse, ()>(endpoint.as_str(), "GET", RequestBody::None)
+            .await?;
+
+        Ok(response)
+    }
+
+    /// Initiates a bulk transfer.
+    ///
+    /// Sends a `POST` request to `/bulk-transfers` with a list of individual transfers.
+    ///
+    /// # Parameters
+    /// - `options`: Bulk transfer options containing a vector of individual transfer details.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     use chapa_rust::client::ChapaClient;
+    ///     use chapa_rust::config::ChapaConfigBuilder;
+    ///     use chapa_rust::models::transfer::{BulkTransferOptions, TransferEntry};
+    ///     dotenvy::dotenv().ok();
+    ///     let config = ChapaConfigBuilder::new().build().unwrap();
+    ///     let mut client = ChapaClient::from_config(config).unwrap();
+    ///     let options = BulkTransferOptions {
+    ///         transfers: vec![
+    ///             TransferEntry {
+    ///                 account_name: "John Doe".to_string(),
+    ///                 account_number: "0123456789".to_string(),
+    ///                 amount: 50,
+    ///                 bank_code: 946,
+    ///                 currency: "ETB".to_string(),
+    ///                 reference: "bulk-tx-1".to_string(),
+    ///             },
+    ///             // ... more entries
+    ///         ],
+    ///     };
+    ///     let response = client.bulk_transfer(options).await.unwrap();
+    /// }
+    /// ```
+    pub async fn bulk_transfer(
+        &self,
+        options: BulkTransferOptions,
+    ) -> Result<BulkTransferResponse> {
+        let respose = self
+            .make_request::<BulkTransferResponse, BulkTransferOptions>(
+                "bulk-transfers",
+                "POST",
+                RequestBody::Json(options),
+            )
+            .await?;
+        Ok(respose)
+    }
+
+    /// Lists all transfers, optionally filtered by date, currency, or status.
+    ///
+    /// This function sends a `GET` request to `/transfers` with optional query parameters
+    /// for filtering the results. The response contains paginated transfer data.
+    ///
+    /// # Parameters
+    /// - `from_date`: Optional start date/time filter (UTC, format `YYYY-MM-DD` or `YYYY-MM-DDTHH:mm:ss`).
+    /// - `to_date`: Optional end date/time filter (UTC, must be ≥ `from_date` if both are provided).
+    /// - `currency`: Optional currency filter (e.g., `"ETB"`, `"USD"`).
+    /// - `status`: Optional status filter (e.g., `"success"`, `"pending"`, `"failed"`).
+    ///
+    /// # Example
+    /// ```
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     use chapa_rust::client::ChapaClient;
+    ///     use chapa_rust::config::ChapaConfigBuilder;
+    ///     dotenvy::dotenv().ok();
+    ///     let config = ChapaConfigBuilder::new().build().unwrap();
+    ///     let mut client = ChapaClient::from_config(config).unwrap();
+    ///     // Get all transfers without filters
+    ///     let all = client.get_all_transfers(None, None, None, None).await.unwrap();
+    ///     // Filter by date range and status
+    ///     let filtered = client.get_all_transfers(
+    ///         Some("2025-03-01"),
+    ///         Some("2025-03-10"),
+    ///         Some("ETB"),
+    ///         Some("success"),
+    ///     ).await.unwrap();
+    /// }
+    /// ```
+    /// # Errors
+    /// Returns an error if the request fails or the response cannot be deserialized.
+    pub async fn get_all_transfers(
+        &self,
+        from_date: Option<&str>,
+        to_date: Option<&str>,
+        currency: Option<&str>,
+        status: Option<&str>,
+    ) -> Result<GetTransactionsResponse> {
+        let mut endpoint = "transfers".to_string();
+        // Build query parameters
+        let mut query_params = Vec::new();
+        if let Some(d) = from_date {
+            query_params.push(("from_date", d));
+        }
+        if let Some(d) = to_date {
+            query_params.push(("to_date", d));
+        }
+        if let Some(c) = currency {
+            query_params.push(("currency", c));
+        }
+        if let Some(s) = status {
+            query_params.push(("status", s));
+        }
+
+        if !query_params.is_empty() {
+            let query_string = query_params
+                .iter()
+                .map(|(k, v)| format!("{}={}", k, v))
+                .collect::<Vec<_>>()
+                .join("&");
+            endpoint.push('?');
+            endpoint.push_str(&query_string);
+        }
+        let respose = self
+            .make_request::<GetTransactionsResponse, ()>(
+                endpoint.as_str(),
+                "GET",
+                RequestBody::None,
+            )
+            .await?;
+        Ok(respose)
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -29,8 +29,9 @@ use crate::{
     models::{
         payment::{CreateSubaccountOptions, InitializeOptions},
         response::{
-            BulkTransferResponse, GetBanksResponse, GetTransactionsResponse, InitializeResponse,
-            SubaccountResponse, TransactionEventsResponse, TransferResponse, VerifyResponse,
+            BulkTransferResponse, GetAllTransactionResponse, GetAllTransfersResponse,
+            GetBanksResponse, InitializeResponse, SubaccountResponse, TransactionEventsResponse,
+            TransferResponse, VerifyResponse,
         },
         transaction::CancelTransactionResponse,
         transfer::{BulkTransferOptions, InitateTransferOptions},
@@ -311,9 +312,9 @@ impl ChapaClient {
     /// # Errors
     /// Returns an error if the network request fails or if the response
     /// cannot be deserialized.
-    pub async fn get_all_transactions(&self) -> Result<GetTransactionsResponse> {
+    pub async fn get_all_transactions(&self) -> Result<GetAllTransactionResponse> {
         let respose = self
-            .make_request::<GetTransactionsResponse, ()>("transactions", "GET", RequestBody::None)
+            .make_request::<GetAllTransactionResponse, ()>("transactions", "GET", RequestBody::None)
             .await?;
         Ok(respose)
     }
@@ -400,24 +401,36 @@ impl ChapaClient {
     /// async fn main() {
     ///     use chapa_rust::client::ChapaClient;
     ///     use chapa_rust::config::ChapaConfigBuilder;
-    ///     use chapa_rust::models::transfer::{BulkTransferOptions, TransferEntry};
+    ///     use chapa_rust::models::transfer::BulkTransferOptions;
+    ///     use chapa_rust::models::{bank::Currency, transfer::InitateTransferOptions};
     ///     dotenvy::dotenv().ok();
     ///     let config = ChapaConfigBuilder::new().build().unwrap();
-    ///     let mut client = ChapaClient::from_config(config).unwrap();
+    ///     let client = ChapaClient::from_config(config).unwrap();
     ///     let options = BulkTransferOptions {
-    ///         transfers: vec![
-    ///             TransferEntry {
-    ///                 account_name: "John Doe".to_string(),
-    ///                 account_number: "0123456789".to_string(),
-    ///                 amount: 50,
-    ///                 bank_code: 946,
-    ///                 currency: "ETB".to_string(),
-    ///                 reference: "bulk-tx-1".to_string(),
+    ///         title: "This Month Salary!".to_string(),
+    ///         currency: Currency::ETB,
+    ///         bulk_data: vec![
+    ///             InitateTransferOptions {
+    ///                 account_name: "Israel Goytom".to_string(),
+    ///                 account_number: "09xxxxxxxx".to_string(),
+    ///                 amount: "100".to_string(),
+    ///                 reference: "qwertyuuiop".to_string(),
+    ///                 bank_code: 128,
     ///             },
-    ///             // ... more entries
+    ///             InitateTransferOptions {
+    ///                 account_name: "Abenezer Haymanot".to_string(),
+    ///                 account_number: "09xxxxxxxx".to_string(),
+    ///                 amount: "120".to_string(),
+    ///                 reference: "kjl1139471".to_string(),
+    ///                 bank_code: 128,
+    ///             },
     ///         ],
     ///     };
-    ///     let response = client.bulk_transfer(options).await.unwrap();
+    ///     let result = client.bulk_transfer(options).await;
+    ///     match result {
+    ///         Ok(banks) => println!("{:#?}", banks),
+    ///         Err(e) => eprintln!("{:#?}", e),
+    ///     }
     /// }
     /// ```
     pub async fn bulk_transfer(
@@ -473,7 +486,7 @@ impl ChapaClient {
         to_date: Option<&str>,
         currency: Option<&str>,
         status: Option<&str>,
-    ) -> Result<GetTransactionsResponse> {
+    ) -> Result<GetAllTransfersResponse> {
         let mut endpoint = "transfers".to_string();
         // Build query parameters
         let mut query_params = Vec::new();
@@ -489,7 +502,6 @@ impl ChapaClient {
         if let Some(s) = status {
             query_params.push(("status", s));
         }
-
         if !query_params.is_empty() {
             let query_string = query_params
                 .iter()
@@ -500,7 +512,7 @@ impl ChapaClient {
             endpoint.push_str(&query_string);
         }
         let respose = self
-            .make_request::<GetTransactionsResponse, ()>(
+            .make_request::<GetAllTransfersResponse, ()>(
                 endpoint.as_str(),
                 "GET",
                 RequestBody::None,

--- a/src/client.rs
+++ b/src/client.rs
@@ -27,8 +27,11 @@ use crate::{
     config::{ChapaConfig, ChapaConfigBuilder},
     error::{ChapaError, Result},
     models::{
-        payment::InitializeOptions,
-        response::{GetBanksResponse, InitializeResponse, VerifyResponse},
+        payment::{CreateSubaccountOptions, InitializeOptions},
+        response::{
+            GetBanksResponse, GetTransactionsResponse, InitializeResponse, SubaccountResponse,
+            TransactionEventsResponse, VerifyResponse,
+        },
         transaction::CancelTransactionResponse,
     },
 };
@@ -235,348 +238,83 @@ impl ChapaClient {
             .await?;
         Ok(response)
     }
-}
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use mockito::{self, Matcher};
-
-    #[tokio::test]
-    async fn test_get_banks() {
-        let mut server = mockito::Server::new_async().await;
-        let success = server
-            .mock("GET", "/v1/banks")
-            .match_header(
-                "authorization",
-                Matcher::Regex(r#"^Bearer .+$"#.to_string()),
-            )
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(
-                serde_json::to_string(&serde_json::json!({
-                "message": "Banks retrieved",
-                "data": [
-                    {
-                        "id": 130,
-                        "slug": "abay_bank",
-                        "swift": "ABAYETAA",
-                        "name": "Abay Bank",
-                        "acct_length": 16,
-                        "country_id": 1,
-                        "is_mobilemoney": null,
-                        "is_active": 1,
-                        "is_rtgs": 1,
-                        "active": 1,
-                        "is_24hrs": null,
-                        "created_at": "2023-01-24T04:28:30.000000Z",
-                        "updated_at": "2024-08-03T08:10:24.000000Z",
-                        "currency": "ETB"
-                    }
-                ]
-                        }))
-                .unwrap(),
-            )
-            .create_async()
-            .await;
-
-        let failure = server
-            .mock("GET", "/v1/banks")
-            .match_header(
-                "authorization",
-                Matcher::Regex(r#"^Bearer .+$"#.to_string()),
-            )
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(
-                serde_json::to_string(&serde_json::json!({
-                "message": "Invalid API Key	",
-                "status": "failed",
-                "data": null
-                }))
-                .unwrap(),
-            )
-            .create_async()
-            .await;
-
-        let config = ChapaConfigBuilder::new()
-            .base_url(server.url())
-            .api_key("CHASECK-xxxxxxxxxxxxxxxx")
-            .build()
-            .unwrap();
-        let mut client = ChapaClient::from_config(config).unwrap();
-
-        // ACT for success
-        let response_success = client.get_banks().await.unwrap();
-        assert!(!response_success.message.is_null());
-        assert!(response_success.data.is_some());
-
-        // ACT for failure
-        let response_failure = client.get_banks().await.unwrap();
-        assert!(!response_failure.message.is_null());
-        // assert_eq!(response_failure.status, "failed");
-        assert!(response_failure.data.is_none());
-
-        success.assert_async().await;
-        failure.assert_async().await;
+    /// Retrieves the event timeline for a given transaction reference ID.
+    /// This Functions `GET` to request `transaction/events/{ref_id}`
+    /// and allows you to view the timeline for a transaction.
+    /// A transaction timeline is a list of events that happened to a selected transaction
+    ///
+    /// # Arguments
+    /// * `ref_id` - the reference id to that specific transaction
+    ///
+    /// # Example
+    /// ```
+    /// #[tokio::main]
+    /// async fn main() {
+    /// use chapa_rust::{client::ChapaClient, config::ChapaConfigBuilder};
+    /// dotenvy::dotenv().ok();
+    /// let config = ChapaConfigBuilder::new().build().unwrap();
+    /// let mut client = ChapaClient::from_config(config).unwrap();
+    /// let ref_id = "chewatatest-6669";
+    /// let response = client.get_transaction_events(ref_id).await.unwrap();
+    /// }
+    /// ```
+    pub async fn get_transaction_events(&self, ref_id: &str) -> Result<TransactionEventsResponse> {
+        let endpoint = format!("transaction/events/{}", ref_id);
+        let response = self
+            .make_request::<TransactionEventsResponse, ()>(endpoint.as_str(), "GET", None)
+            .await?;
+        Ok(response)
     }
-
-    #[tokio::test]
-    async fn test_initialize_transaction() {
-        let mut server = mockito::Server::new_async().await;
-        let success = server
-            .mock("POST", "/v1/transaction/initialize")
-            .match_header(
-                "authorization",
-                Matcher::Regex(r#"^Bearer .+$"#.to_string()),
-            )
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(
-                serde_json::to_string(&serde_json::json!({
-                "message": "Hosted Link",
-                "status": "success",
-                "data": {
-                    "checkout_url": "https://checkout.chapa.co/checkout/payment/V38JyhpTygC9QimkJrdful9oEjih0heIv53eJ1MsJS6xG"
-                    }
-                }))
-                .unwrap(),
-            )
-            .create_async()
-            .await;
-
-        let failure = server
-            .mock("POST", "/v1/transaction/initialize")
-            .match_header(
-                "authorization",
-                Matcher::Regex(r#"^Bearer .+$"#.to_string()),
-            )
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(
-                serde_json::to_string(&serde_json::json!({
-                  "message": "Authorization required	",
-                  "status": "failed",
-                  "data": null
-                }))
-                .unwrap(),
-            )
-            .create_async()
-            .await;
-
-        let config = ChapaConfigBuilder::new()
-            .base_url(server.url())
-            .api_key("CHASECK-xxxxxxxxxxxxxxxx")
-            .build()
-            .unwrap();
-        let mut client = ChapaClient::from_config(config).unwrap();
-
-        let transaction_success = InitializeOptions {
-            amount: "100".to_string(),
-            currency: "ETB".to_string(),
-            email: Some("customer@gmail.com".to_string()),
-            first_name: Some("John".to_string()),
-            last_name: Some("Doe".to_string()),
-            tx_ref: String::from("some_generated_tax_ref"),
-            ..Default::default()
-        };
-        let transaction_failure = InitializeOptions {
-            ..Default::default()
-        };
-
-        // ACT for success
-        let response_success = client
-            .initialize_transaction(transaction_success)
-            .await
-            .unwrap();
-        assert_eq!(response_success.status, "success");
-        assert!(!response_success.message.is_null());
-        assert!(response_success.data.is_some());
-
-        // ACT for failure
-        let response_failure = client
-            .initialize_transaction(transaction_failure)
-            .await
-            .unwrap();
-        assert_eq!(response_failure.status, "failed");
-        assert!(!response_failure.message.is_null());
-        assert!(response_failure.data.is_none());
-
-        success.assert_async().await;
-        failure.assert_async().await;
+    /// Retrieves a list of all transactions
+    pub async fn get_all_transactions(&self) -> Result<GetTransactionsResponse> {
+        let respose = self
+            .make_request::<GetTransactionsResponse, ()>("transactions", "GET", None)
+            .await?;
+        Ok(respose)
     }
-
-    #[tokio::test]
-    async fn test_verify_transaction() {
-        let mut server = mockito::Server::new_async().await;
-        let success = server
-            .mock("GET", "/v1/transaction/verify/chewatatest-6669")
-            .match_header(
-                "authorization",
-                Matcher::Regex(r#"^Bearer .+$"#.to_string()),
+    ///  Create a subaccountCreate a subaccount    
+    /// Sends a `POST` request to `/subaccount` with subaccout data
+    /// details provided in the [`CreateSubaccountOptions`] struct.
+    ///
+    /// # Parameters
+    /// - `subaccount`: The subaccout details (account_name, bank_code, split_value, etc.)
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// #[tokio::main]
+    /// async fn main() {
+    /// use chapa_rust::{
+    ///       client::ChapaClient,
+    ///       config::ChapaConfigBuilder,
+    ///       models::payment::{CreateSubaccountOptions, SplitType}
+    /// };
+    /// dotenvy::dotenv().ok();
+    /// let config = ChapaConfigBuilder::new().build().unwrap();
+    /// let mut client = ChapaClient::from_config(config).unwrap();
+    /// let subaccount = CreateSubaccountOption {
+    ///         account_name: "Abebe Bikila ".to_string(),
+    ///         bank_code: 128,
+    ///         account_number: "0123456789".to_string(),
+    ///         split_type: Some(SplitType::PERCENTAGE),
+    ///         split_value: Some(0.2),
+    ///     };
+    /// let response = client.create_subaccount(subaccount).await.unwrap();
+    /// }
+    /// ```
+    /// # Errors
+    /// Returns an error if the request fails or if the response cannot be parsed.
+    pub async fn create_subaccount(
+        &self,
+        subaccount: CreateSubaccountOptions,
+    ) -> Result<SubaccountResponse> {
+        let response = self
+            .make_request::<SubaccountResponse, CreateSubaccountOptions>(
+                "subaccount",
+                "POST",
+                Some(subaccount),
             )
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(
-                serde_json::to_string(&serde_json::json!({
-                "message": "Payment details",
-                "status": "success",
-                "data": {
-                    "first_name": "Bilen",
-                    "last_name": "Gizachew",
-                    "email": "abebech_bekele@gmail.com",
-                    "currency": "ETB",
-                    "amount": 100,
-                    "charge": 3.5,
-                    "mode": "test",
-                    "method": "test",
-                    "type": "API",
-                    "status": "success",
-                    "reference": "6jnheVKQEmy",
-                    "tx_ref": "chewatatest-6669",
-                    "customization": {
-                        "title": "Payment for my favourite merchant",
-                        "description": "I love online payments",
-                        "logo": null
-                    },
-                    "meta": null,
-                    "created_at": "2023-02-02T07:05:23.000000Z",
-                    "updated_at": "2023-02-02T07:05:23.000000Z"
-                  }
-                }))
-                .unwrap(),
-            )
-            .create_async()
-            .await;
-
-        let failure = server
-            .mock("GET", "/v1/transaction/verify/chewatatest-6669")
-            .match_header(
-                "authorization",
-                Matcher::Regex(r#"^Bearer .+$"#.to_string()),
-            )
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(
-                serde_json::to_string(&serde_json::json!({
-                "message": "Invalid transaction or Transaction not found	",
-                "status": "failed",
-                "data": null
-                }))
-                .unwrap(),
-            )
-            .create_async()
-            .await;
-
-        let config = ChapaConfigBuilder::new()
-            .base_url(server.url())
-            .api_key("CHASECK_TEST-XXXXXXXXXXXXXXX")
-            .build()
-            .unwrap();
-        let mut client = ChapaClient::from_config(config).unwrap();
-
-        // ACT for success
-        let response_success = client.verify_transaction("chewatatest-6669").await.unwrap();
-        assert_eq!(response_success.status, "success");
-        assert!(!response_success.message.is_null()); // NOTE: ckeck if it is empty because I suspect there might be a change if I put string comparison.
-        assert!(response_success.data.is_some());
-
-        // ACT for failure
-        let response_failure = client.verify_transaction("chewatatest-6669").await.unwrap();
-        assert_eq!(response_failure.status, "failed");
-        assert!(!response_failure.message.is_null()); // NOTE: check if it is empty because I suspect there might be a change if I put string comparison.
-        assert!(response_failure.data.is_none());
-
-        success.assert_async().await;
-        failure.assert_async().await;
-    }
-
-    #[tokio::test]
-    async fn test_cancel_transaction_success() {
-        let mut server = mockito::Server::new_async().await;
-        let tx_ref = "tx-456-sdf";
-
-        let success_mock = server
-            .mock("PUT", format!("/v1/transaction/cancel/{}", tx_ref).as_str())
-            .match_header(
-                "authorization",
-                Matcher::Regex(r#"^Bearer .+$"#.to_string()),
-            )
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(
-                serde_json::to_string(&serde_json::json!(
-                    {
-                        "message": "Checkout link expired successfully",
-                        "status": "success",
-                        "data": {
-                            "tx_ref": "tx-456-sdf",
-                            "amount": 5,
-                            "currency": "ETB",
-                            "created_at": "2025-10-22T09:10:03.000000Z",
-                            "updated_at": "2025-10-22T09:10:21.000000Z"
-                        }
-                    }
-                ))
-                .unwrap(),
-            )
-            .create_async()
-            .await;
-
-        let config = ChapaConfigBuilder::new()
-            .base_url(server.url())
-            .api_key("CHASECK-xxxxxxxxxxxxxxxx")
-            .build()
-            .unwrap();
-        let client = ChapaClient::from_config(config).unwrap();
-        let response = client.cancel_transaction(tx_ref).await.unwrap();
-        assert_eq!(response.status, "success");
-        assert_eq!(response.message, "Checkout link expired successfully");
-        assert!(response.data.is_some());
-
-        let data = response.data.unwrap();
-        assert_eq!(data.tx_ref, tx_ref);
-        assert_eq!(data.amount, 5.0);
-        assert_eq!(data.currency.as_str(), "ETB");
-
-        success_mock.assert_async().await;
-    }
-
-    #[tokio::test]
-    async fn test_cancel_transaction_already_expired() {
-        let mut server = mockito::Server::new_async().await;
-        let tx_ref = "already-expired-ref";
-        let failure_mock = server
-            .mock("PUT", format!("/v1/transaction/cancel/{}", tx_ref).as_str())
-            .match_header(
-                "authorization",
-                Matcher::Regex(r#"^Bearer .+$"#.to_string()),
-            )
-            .with_status(200)
-            .match_header("content-type", "application/json")
-            .with_body(
-                serde_json::to_string(&serde_json::json!({
-                    "message": "Payment link already expired",
-                    "status": "failed",
-                    "data": null
-                }))
-                .unwrap(),
-            )
-            .create_async()
-            .await;
-
-        let config = ChapaConfigBuilder::new()
-            .base_url(server.url())
-            .api_key("CHASECK-xxxxxxxxxxxxxxxx")
-            .build()
-            .unwrap();
-        let client = ChapaClient::from_config(config).unwrap();
-
-        let response = client.cancel_transaction(tx_ref).await.unwrap();
-        assert_eq!(response.status, "failed");
-        assert_eq!(response.message, "Payment link already expired");
-        assert!(response.data.is_none());
-
-        failure_mock.assert_async().await;
+            .await?;
+        Ok(response)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,11 +50,6 @@
 //!
 //! | Category | Methods |
 //! |-----------|----------|
-//! | Transactions | `initialize`, `verify`, `all_transactions`, `transaction_logs` |
-//! | Split Payments | `split_payment` |
-//! | Banks | `list_banks` |
-//! | Subaccounts | `create_subaccount` |
-//! | Transfers | `transfer`, `bulk_transfer`, `verify_transfer`, `all_transfers` |
 //! | Direct Charges | `direct_charge`, `authorize_direct_charge` |
 //! | Utilities | `generate_tx_ref()` |
 //!

--- a/src/models/balances.rs
+++ b/src/models/balances.rs
@@ -1,0 +1,51 @@
+//! Models related to balace .
+use crate::models::bank::Currency;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Data Structer for Swap API
+#[derive(Debug, Serialize)]
+pub struct SwapOptions {
+    /// The ammout of swapable balace
+    pub amount: u64,
+    /// The currency of the balance swaped form (e.g., "ETB", "USD").
+    pub from: Currency,
+    /// The currency of the balance to swap (e.g., "ETB", "USD").
+    pub to: Currency,
+}
+/// Data Structer for Balace Represenation
+#[derive(Debug, Deserialize)]
+pub struct Balance {
+    /// The currency for the balance (e.g., "ETB", "USD").
+    pub currency: Currency,
+    /// This is the amount that is available for immediate use.
+    /// You can use this balance for transfers, withdrawals, and other transactions.
+    pub available_balance: f64,
+    ///This represents the balance in your account,
+    /// which are funds that are not yet available for use (funds that have not yet been settled).
+    pub ledger_balance: f64,
+}
+/// Data Structure for Swap API for converting USD to ETB (Ethiopian Birr).
+#[derive(Debug, Deserialize)]
+pub struct SwapData {
+    /// The status of the swap balace.
+    pub status: String,
+    ///  The reference ID of the swap procces (Chapa reference)
+    pub ref_id: String,
+    /// The currency of the balance swaped form (e.g., "ETB", "USD").
+    pub from_currency: Currency,
+    /// The currency of the balance to swap (e.g., "ETB", "USD").
+    pub to_currency: Currency,
+    /// The ammout of swapable balace
+    pub amount: f64,
+    /// total amoute of exchage
+    pub exchanged_amount: u64,
+    /// amout of charege by chapa
+    pub charge: u32,
+    /// rate fo convetion rate (dev NOTE:to be honest idk what this mean )
+    pub rate: f64,
+    /// The creation timestamp of the swap entry.
+    pub created_at: DateTime<Utc>,
+    /// The last updated timestamp of the swap entry.
+    pub updated_at: DateTime<Utc>,
+}

--- a/src/models/bank.rs
+++ b/src/models/bank.rs
@@ -30,9 +30,10 @@ pub struct Bank {
 }
 
 /// Represents the supported currencies for banks.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub enum Currency {
     /// Ethiopian Birr
+    #[default]
     ETB,
     /// United States Dollar
     USD,
@@ -42,7 +43,7 @@ impl Currency {
     /// Returns the ISO 4217 currency code as a static string slice.
     /// # Examples
     /// ```
-    /// let currency = ChapaCurrency::ETB;
+    /// let currency = Currency::ETB;
     /// assert_eq!(currency.as_str(), "ETB");
     /// ```
     pub fn as_str(&self) -> &'static str {
@@ -55,7 +56,7 @@ impl Currency {
 
 impl fmt::Display for Currency {
     /// Formats the currency as its three‑letter ISO 4217 code.
-    /// This enables direct use in formatting macros like `println!` and `format!`. Which Result Direct `String`
+    /// This enables direct use in formatting macros like `println!` and `format!`.
     /// # Examples
     /// ```
     /// let currency = ChapaCurrency::USD;

--- a/src/models/bank.rs
+++ b/src/models/bank.rs
@@ -2,6 +2,7 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 /// Represents a single bank entry from Chapa’s bank list.
 #[derive(Debug, Serialize, Deserialize)]
@@ -35,4 +36,32 @@ pub enum Currency {
     ETB,
     /// United States Dollar
     USD,
+}
+
+impl Currency {
+    /// Returns the ISO 4217 currency code as a static string slice.
+    /// # Examples
+    /// ```
+    /// let currency = ChapaCurrency::ETB;
+    /// assert_eq!(currency.as_str(), "ETB");
+    /// ```
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::ETB => "ETB",
+            Self::USD => "USD",
+        }
+    }
+}
+
+impl fmt::Display for Currency {
+    /// Formats the currency as its three‑letter ISO 4217 code.
+    /// This enables direct use in formatting macros like `println!` and `format!`. Which Result Direct `String`
+    /// # Examples
+    /// ```
+    /// let currency = ChapaCurrency::USD;
+    /// assert_eq!(format!("{}", currency), "USD");
+    /// ```
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -22,6 +22,7 @@
 //!
 //! All response models can be directly deserialized from Chapa API JSON responses.
 
+pub mod balances;
 pub mod bank;
 pub mod payment;
 pub mod response;

--- a/src/models/payment.rs
+++ b/src/models/payment.rs
@@ -82,6 +82,21 @@ pub enum SplitType {
     FLAT,
 }
 
+impl SplitType {
+    /// Returns the ISO 4217 currency code as a static string slice.
+    /// # Examples
+    /// ```
+    /// let currency = Currency::ETB;
+    /// assert_eq!(currency.as_str(), "ETB");
+    /// ```
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::PERCENTAGE => "percentage",
+            Self::FLAT => "flat",
+        }
+    }
+}
+
 /// Represents the checkout URL provided by Chapa after a successful initialization.
 #[derive(Debug, Deserialize)]
 pub struct CheckoutURL {
@@ -102,7 +117,7 @@ pub struct VerifyData {
     /// The email address of the customer.
     pub email: Option<String>,
     /// The currency for the transaction (e.g., "ETB", "USD").
-    pub currency: Option<String>,
+    pub currency: Option<Currency>,
     /// The amount to be charged in the transaction.
     pub amount: f64,
     /// The charge for the transaction.

--- a/src/models/payment.rs
+++ b/src/models/payment.rs
@@ -3,6 +3,8 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::models::bank::Currency;
+
 // TODO: check the type of `amount` field has some inconsistency in the docs, sometimes it's string sometimes number
 // ------------------------------------- Initialize Payment ---------------------------------------------
 
@@ -18,7 +20,7 @@ pub struct InitializeOptions {
     /// The phone number of the customer.
     pub phone_number: Option<String>,
     /// The currency for the transaction (e.g., "ETB", "USD").
-    pub currency: String,
+    pub currency: Currency,
     /// The amount to be charged in the transaction.
     pub amount: String,
     /// A unique reference for the transaction.
@@ -37,13 +39,24 @@ pub struct InitializeOptions {
 
 /// Represents a subaccount for payment splitting.
 #[derive(Debug, Serialize, Deserialize)]
-pub struct Subaccount {
-    /// The unique identifier of the subaccount.
-    pub id: String,
+pub struct CreateSubaccountOptions {
+    /// The bank accout owner name.
+    pub account_name: String,
+    /// The unique identifier of the bank code form [get banks](https://developer.chapa.co/transfer/list-banks) endpoint.
+    pub bank_code: u32,
+    /// The banck account number for subaccount.
+    pub account_number: String,
     /// The type of split (e.g., percentage or flat).
     pub split_type: Option<SplitType>,
     /// The value of the split (e.g., percentage value or flat amount).
     pub split_value: Option<f64>,
+}
+
+/// Represents a subaccount for payment splitting.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SubaccountData {
+    /// The unique identifier of the subaccount.
+    pub id: String, // NOTE  this is usialy UUID for the next reales we will fix this
 }
 
 /// Customization options for the payment interface.

--- a/src/models/response.rs
+++ b/src/models/response.rs
@@ -5,7 +5,9 @@ use serde_json::Value;
 
 use crate::models::{
     bank::Bank,
-    payment::{CheckoutURL, VerifyData},
+    payment::{CheckoutURL, SubaccountData, VerifyData},
+    transaction::{GetTransactionsData, TransactionEventData},
+    transfer::{BulkTransferData, MetaPagination, TransferData},
 };
 
 /// Represents a generic response from the Chapa API.
@@ -20,6 +22,21 @@ pub struct ChapaResponse<T> {
     pub data: T,
 }
 
+/// Datat Structe GetTransactionsResponse , which t allows you to view all the transactions the Chapa API
+#[derive(Debug, Deserialize)]
+pub struct ChapaTransferListResponse {
+    /// The status message of the response.
+    pub message: String, // FIX: Changed to Value to handle empty strings or other types, since some responses might return non-string messages
+    #[serde(default = "unspecified_status")]
+    /// The status of the response.
+    pub status: String,
+    /// Pagination details for a list of transactions.
+    #[serde(alias = "pagination")]
+    pub meta: Option<MetaPagination>, // often returned at top level
+    /// The data section of the response.
+    pub data: Option<Vec<TransferData>>, // array of transfers
+}
+
 fn unspecified_status() -> String {
     "Unspecified".to_string()
 }
@@ -30,3 +47,15 @@ pub type GetBanksResponse = ChapaResponse<Option<Vec<Bank>>>;
 pub type InitializeResponse = ChapaResponse<Option<CheckoutURL>>;
 /// Type alias for VerifyResponse, which contains the verification data.
 pub type VerifyResponse = ChapaResponse<Option<VerifyData>>;
+/// Type alias for SubaccountResponse, which contains the subaccount data.
+pub type SubaccountResponse = ChapaResponse<SubaccountData>;
+/// Type alias for TransactionEventsResponse, which allows you to view the timeline for a transaction
+pub type TransactionEventsResponse = ChapaResponse<Option<Vec<TransactionEventData>>>;
+/// Type alias for GetTransactionsResponse , which t allows you to view all the transactions
+pub type GetAllTransfersResponse = ChapaTransferListResponse;
+/// Type alias for All Transaction respose wich conatine  all the transactions
+pub type GetAllTransactionResponse = ChapaResponse<Option<GetTransactionsData>>;
+/// trnasfer
+pub type TransferResponse = ChapaResponse<Option<TransferData>>;
+/// bulk trasfer
+pub type BulkTransferResponse = ChapaResponse<Option<BulkTransferData>>;

--- a/src/models/response.rs
+++ b/src/models/response.rs
@@ -49,7 +49,7 @@ pub type InitializeResponse = ChapaResponse<Option<CheckoutURL>>;
 /// Type alias for VerifyResponse, which contains the verification data.
 pub type VerifyResponse = ChapaResponse<Option<VerifyData>>;
 /// Type alias for SubaccountResponse, which contains the subaccount data.
-pub type SubaccountResponse = ChapaResponse<SubaccountData>;
+pub type SubaccountResponse = ChapaResponse<Option<SubaccountData>>;
 /// Type alias for TransactionEventsResponse, which allows you to view the timeline for a transaction
 pub type TransactionEventsResponse = ChapaResponse<Option<Vec<TransactionEventData>>>;
 /// Type alias for GetTransactionsResponse , which t allows you to view all the transactions

--- a/src/models/response.rs
+++ b/src/models/response.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use crate::models::{
+    balances::{Balance, SwapData},
     bank::Bank,
     payment::{CheckoutURL, SubaccountData, VerifyData},
     transaction::{GetTransactionsData, TransactionEventData},
@@ -55,7 +56,13 @@ pub type TransactionEventsResponse = ChapaResponse<Option<Vec<TransactionEventDa
 pub type GetAllTransfersResponse = ChapaTransferListResponse;
 /// Type alias for All Transaction respose wich conatine  all the transactions
 pub type GetAllTransactionResponse = ChapaResponse<Option<GetTransactionsData>>;
-/// trnasfer
+/// Type alias for trnasfer
 pub type TransferResponse = ChapaResponse<Option<TransferData>>;
-/// bulk trasfer
+/// Type alias for  bulk trasfer
 pub type BulkTransferResponse = ChapaResponse<Option<BulkTransferData>>;
+/// Type alias for GetSingleBalanceResponse respose balance information for a specific currency
+pub type GetSingleCurrencyBalanceResponse = ChapaResponse<Option<Balance>>;
+/// Type alias for BalanceResponse respose to retrieve your current account balance information
+pub type GetBalanceResponse = ChapaResponse<Option<Vec<Balance>>>;
+/// Type alias for GetSwapResponse Swap API for converting USD to ETB
+pub type GetSwapResponse = ChapaResponse<Option<SwapData>>;

--- a/src/models/transaction.rs
+++ b/src/models/transaction.rs
@@ -2,6 +2,8 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::models::bank::Currency;
+
 /// Represents the response from Chapa when fetching all transactions.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetTransactionsResponse {
@@ -75,4 +77,31 @@ pub struct Pagination {
     pub next_page_url: Option<String>,
     /// URL to the previous page of transactions.
     pub prev_page_url: Option<String>,
+}
+/// Represents  Cancle transaction by its transaction reference
+#[derive(Debug, Deserialize)]
+pub struct CancelTransactionResponse {
+    /// Status of the cancel transaction Respose
+    pub status: String,
+    /// message Containg deatile about the Respose
+    pub message: String,
+    /// Data about the canceled in deatile, like its tx_ref, amout
+    pub data: Option<CancelTransactionData>,
+}
+/// Data structure representing a canceled transaction response from Chapa.
+#[derive(Debug, Deserialize)]
+pub struct CancelTransactionData {
+    /// The unique transaction reference string.
+    pub tx_ref: String,
+
+    /// The transaction amount.
+    pub amount: f64,
+
+    /// The transaction currency code.
+    pub currency: Currency,
+    /// When the transaction was created.
+    pub created_at: DateTime<Utc>,
+
+    /// When the cancellation occurred.
+    pub updated_at: DateTime<Utc>,
 }

--- a/src/models/transaction.rs
+++ b/src/models/transaction.rs
@@ -1,19 +1,7 @@
 //! Models related to get_transactions API responses.
+use crate::models::bank::Currency;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-
-use crate::models::bank::Currency;
-
-/// Represents the response from Chapa when fetching all transactions.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct GetTransactionsResponse {
-    /// The status message of the response.
-    pub message: String,
-    /// The status of the response.
-    pub status: String,
-    /// The data containing the list of transactions and pagination info.
-    pub data: GetTransactionsData,
-}
 
 /// Represents the data section of the GetTransactionsResponse.
 #[derive(Debug, Serialize, Deserialize)]
@@ -30,13 +18,13 @@ pub struct Customer {
     /// The unique identifier of the customer.
     pub id: u32,
     /// The first name of the customer.
-    pub first_name: String,
+    pub first_name: Option<String>,
     /// The last name of the customer.
-    pub last_name: String,
+    pub last_name: Option<String>,
     /// The email address of the customer.
-    pub email: String,
+    pub email: Option<String>,
     /// The mobile number of the customer.
-    pub mobile: String,
+    pub mobile: Option<String>,
 }
 
 /// Represents a transaction in Chapa.
@@ -57,7 +45,7 @@ pub struct Transaction {
     /// The charge applied to the transaction.
     pub charge: String,
     /// The unique identifier of the transaction.
-    pub trans_id: String,
+    pub trans_id: Option<String>,
     /// The payment method used for the transaction.
     pub payment_method: String,
     /// The customer associated with the transaction.
@@ -88,20 +76,32 @@ pub struct CancelTransactionResponse {
     /// Data about the canceled in deatile, like its tx_ref, amout
     pub data: Option<CancelTransactionData>,
 }
-/// Data structure representing a canceled transaction response from Chapa.
+/// Data structure representing a canceled transaction response.
 #[derive(Debug, Deserialize)]
 pub struct CancelTransactionData {
     /// The unique transaction reference string.
     pub tx_ref: String,
-
     /// The transaction amount.
     pub amount: f64,
-
     /// The transaction currency code.
     pub currency: Currency,
     /// When the transaction was created.
     pub created_at: DateTime<Utc>,
-
     /// When the cancellation occurred.
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Data structure representing a transaction  events response .
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TransactionEventData {
+    /// transaction event uinque number
+    pub item: i32,
+    /// Message containg detaile about the event
+    pub message: String,
+    /// type of the event
+    pub r#type: String,
+    /// When the event was initally created.
+    pub created_at: DateTime<Utc>,
+    /// When the evet occurred/updated.
     pub updated_at: DateTime<Utc>,
 }

--- a/src/models/transfer.rs
+++ b/src/models/transfer.rs
@@ -36,13 +36,15 @@ pub struct MetaPagination {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct InitateTransferOptions {
     /// The name of the account holder.
-    pub account_name: String,
+    pub account_name: Option<String>,
     /// The bank account number to which the transfer will be made.
     pub account_number: String,
     /// The amount to be transferred.
     pub amount: String,
+    /// ETB or USD
+    pub currency: Option<Currency>,
     /// A unique reference for the transfer.
-    pub reference: String,
+    pub reference: Option<String>,
     /// The bank code of the recipient's bank.
     pub bank_code: u32,
 }

--- a/src/models/transfer.rs
+++ b/src/models/transfer.rs
@@ -1,31 +1,99 @@
 //! Models related to bank transfers.
 
+use crate::models::bank::Currency;
+
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+
+/// Represents pagination details for a list of transactions.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MetaPagination {
+    /// Page number of the current set of transactions.
+    pub current_page: u32,
+    /// URL to the first page of transactions.
+    pub first_page_url: String,
+    /// Page number of the last set of transactions.
+    pub last_page: u32,
+    /// URL to the last page of transactions.
+    pub last_page_url: Option<String>,
+    /// URL to the next page page of transactions.
+    pub next_page_url: Option<String>,
+    /// URL to the this current page of transactions.
+    pub path: Option<String>,
+    /// How many transactions are in a single page.
+    pub per_page: u32,
+    /// URL to the previous page of transactions.
+    pub prev_page_url: Option<String>,
+    /// To
+    pub to: u32,
+    /// Total
+    pub total: u32,
+    /// error
+    pub error: Vec<String>,
+}
 
 /// Represents the options required to initiate a bank transfer.
 #[derive(Debug, Serialize, Deserialize)]
-pub struct TransferOptions {
+pub struct InitateTransferOptions {
     /// The name of the account holder.
     pub account_name: String,
     /// The bank account number to which the transfer will be made.
     pub account_number: String,
     /// The amount to be transferred.
     pub amount: String,
-    /// The currency in which the transfer will be made.
-    pub currency: String,
     /// A unique reference for the transfer.
     pub reference: String,
     /// The bank code of the recipient's bank.
     pub bank_code: u32,
 }
 
-/// Represents the response received after initiating a bank transfer.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct TransferResponse {
-    /// A message providing additional information about the transfer.
-    pub message: String,
-    /// The status of the transfer (e.g., "pending", "completed").
-    pub status: String,
-    /// Additional data related to the transfer.
-    pub data: String,
+/// Represents the detailed data received when bulk transaction created .
+#[derive(Debug, Deserialize)]
+pub struct TransferData {
+    /// The name of the account holder.
+    pub account_name: String,
+    /// The bank account number to which the transfer will be made.
+    pub account_number: String,
+    /// ETB or USD
+    pub currency: Currency,
+    /// AMOUT
+    pub amount: u32,
+    /// 100,
+    pub charge: u32, // 0,
+    /// trasfer method
+    pub transfer_type: String, // "bank",
+    /// chapa transfer id
+    pub chapa_reference: String, // "4d6a7cb7-0d51-4c27-9a19-cc3f066c85a3",
+    /// bank code form chapa
+    pub bank_code: u32, // 128,
+    /// bank name
+    pub bank_name: String, // "Bunna Bank",
+    /// cross partiy reffecnce
+    pub bank_reference: Option<String>, // null,
+    /// stuats of the transactions
+    pub status: String, // "success",
+    /// transaction refectc id
+    pub reference: Option<String>, // "chewatatest-6669",
+    /// The timestamp when the transaction was created.
+    pub created_at: DateTime<Utc>,
+    /// The timestamp when the transaction was last updated.
+    pub updated_at: DateTime<Utc>,
+}
+/// bulk trasfer options
+#[derive(Debug, Serialize)]
+pub struct BulkTransferOptions {
+    /// The title to be displayed on the payment interface.
+    pub title: String,
+    /// The currency for the transaction (e.g., "ETB", "USD").
+    pub currency: Currency,
+    /// The list of Bulk Data transfer
+    pub bulk_data: Vec<InitateTransferOptions>,
+}
+/// dtat type for bulk data transfer
+#[derive(Debug, Deserialize)]
+pub struct BulkTransferData {
+    /// id of the bulk truafer
+    pub id: u64,
+    /// timespam for when the trasaction is created
+    pub created_at: DateTime<Utc>,
 }

--- a/tests/balances_test.rs
+++ b/tests/balances_test.rs
@@ -1,0 +1,127 @@
+use chapa_rust::{
+    client::ChapaClient,
+    config::ChapaConfigBuilder,
+    models::{balances::SwapOptions, bank::Currency},
+};
+use mockito::{Matcher, Server};
+use serde_json::json;
+
+#[tokio::test]
+async fn test_get_balances_success() {
+    let mut server = Server::new_async().await;
+
+    let success = server
+        .mock("GET", "/v1/balances")
+        .match_header("authorization", Matcher::Regex(r"^Bearer .+$".to_string()))
+        .with_status(200)
+        .with_body(
+            serde_json::to_string(&serde_json::json!({
+            "status": "success",
+            "message": "Balances fetched",
+            "data": [
+                {"currency": "ETB", "available_balance": 1000.0, "ledger_balance": 1200.0},
+                {"currency": "USD", "available_balance": 50.0, "ledger_balance": 50.0}
+            ]
+            }))
+            .unwrap(),
+        )
+        .create_async()
+        .await;
+
+    let config = ChapaConfigBuilder::new()
+        .base_url(server.url())
+        .api_key("CHASECK_TEST-xxxxxxxxxxxxxxxx")
+        .build()
+        .unwrap();
+    let client = ChapaClient::from_config(config).unwrap();
+
+    let response = client.get_balances().await.unwrap();
+    assert!(response.data.is_some());
+    assert!(response.data.is_some());
+
+    success.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_get_balances_failure() {
+    let mut server = Server::new_async().await;
+
+    let failure = server
+        .mock("GET", "/v1/balances")
+        .match_header("authorization", Matcher::Regex(r"^Bearer .+$".to_string()))
+        .with_status(200)
+        .with_body(
+            serde_json::to_string(&serde_json::json!({
+              "message": "Invalid API Key",
+              "status": "failed",
+              "data": null
+            }))
+            .unwrap(),
+        )
+        .create_async()
+        .await;
+
+    let config = ChapaConfigBuilder::new()
+        .base_url(server.url())
+        .api_key("CHASECK_TEST-xxxxxxxxxxxxxxxx")
+        .build()
+        .unwrap();
+    let client = ChapaClient::from_config(config).unwrap();
+
+    let response = client.get_balances().await.unwrap();
+    assert_eq!(response.status, "failed");
+    assert!(response.data.is_none());
+
+    failure.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_swap_currency() {
+    let mut server = Server::new_async().await;
+
+    let mock = server
+        .mock("POST", "/v1/swap")
+        .match_header("authorization", Matcher::Regex(r"^Bearer .+$".to_string()))
+        .with_status(200)
+        .with_body(
+            serde_json::to_string(&json!({
+              "message": "Swap has been made successfully.",
+              "status": "success",
+              "data": {
+                "status": "Success",
+                "ref_id": "SWPfSqc5BiwcC",
+                "from_currency": "USD",
+                "to_currency": "ETB",
+                "amount": 1,
+                "exchanged_amount": 127,
+                "charge": 0,
+                "rate": 127,
+                "created_at": "2025-04-23T08:50:46.000000Z",
+                "updated_at": "2025-04-23T08:50:46.000000Z"
+            }
+             }))
+            .unwrap(),
+        )
+        .create_async()
+        .await;
+
+    let config = ChapaConfigBuilder::new()
+        .base_url(server.url())
+        .api_key("CHASECK_TEST-xxxxxxxxxxxxxxxx")
+        .build()
+        .unwrap();
+    let client = ChapaClient::from_config(config).unwrap();
+
+    let options = SwapOptions {
+        amount: 100,
+        from: Currency::USD,
+        to: Currency::ETB,
+    };
+
+    let response = client.swap_currency(options).await.unwrap();
+    assert!(response.data.is_some());
+
+    assert_eq!(response.status, "success");
+
+    mock.assert_async().await;
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,3 +1,4 @@
+mod balances_test;
 mod subaccounts_test;
 mod transaction_test;
 mod transfer_test;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,7 +1,10 @@
+mod subaccounts_test;
 mod transaction_test;
+mod transfer_test;
 
 use chapa_rust::{client::ChapaClient, config::ChapaConfigBuilder};
 use mockito::{self, Matcher};
+
 #[tokio::test]
 async fn test_get_banks() {
     let mut server = mockito::Server::new_async().await;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,0 +1,82 @@
+mod transaction_test;
+
+use chapa_rust::{client::ChapaClient, config::ChapaConfigBuilder};
+use mockito::{self, Matcher};
+#[tokio::test]
+async fn test_get_banks() {
+    let mut server = mockito::Server::new_async().await;
+    let success = server
+        .mock("GET", "/v1/banks")
+        .match_header(
+            "authorization",
+            Matcher::Regex(r#"^Bearer .+$"#.to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&serde_json::json!({
+            "message": "Banks retrieved",
+            "data": [
+                {
+                    "id": 130,
+                    "slug": "abay_bank",
+                    "swift": "ABAYETAA",
+                    "name": "Abay Bank",
+                    "acct_length": 16,
+                    "country_id": 1,
+                    "is_mobilemoney": null,
+                    "is_active": 1,
+                    "is_rtgs": 1,
+                    "active": 1,
+                    "is_24hrs": null,
+                    "created_at": "2023-01-24T04:28:30.000000Z",
+                    "updated_at": "2024-08-03T08:10:24.000000Z",
+                    "currency": "ETB"
+                }
+            ]
+                    }))
+            .unwrap(),
+        )
+        .create_async()
+        .await;
+
+    let failure = server
+        .mock("GET", "/v1/banks")
+        .match_header(
+            "authorization",
+            Matcher::Regex(r#"^Bearer .+$"#.to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&serde_json::json!({
+            "message": "Invalid API Key	",
+            "status": "failed",
+            "data": null
+            }))
+            .unwrap(),
+        )
+        .create_async()
+        .await;
+
+    let config = ChapaConfigBuilder::new()
+        .base_url(server.url())
+        .api_key("CHASECK-xxxxxxxxxxxxxxxx")
+        .build()
+        .unwrap();
+    let mut client = ChapaClient::from_config(config).unwrap();
+
+    // ACT for success
+    let response_success = client.get_banks().await.unwrap();
+    assert!(!response_success.message.is_null());
+    assert!(response_success.data.is_some());
+
+    // ACT for failure
+    let response_failure = client.get_banks().await.unwrap();
+    assert!(!response_failure.message.is_null());
+    // assert_eq!(response_failure.status, "failed");
+    assert!(response_failure.data.is_none());
+
+    success.assert_async().await;
+    failure.assert_async().await;
+}

--- a/tests/subaccounts_test.rs
+++ b/tests/subaccounts_test.rs
@@ -1,0 +1,51 @@
+use chapa_rust::{
+    client::ChapaClient,
+    config::ChapaConfigBuilder,
+    models::payment::{CreateSubaccountOptions, SplitType},
+};
+use mockito::{Matcher, Server};
+use serde_json::json;
+
+#[tokio::test]
+async fn test_create_subaccount() {
+    let mut server = Server::new_async().await;
+
+    let mock = server
+        .mock("POST", "/v1/subaccount")
+        .match_header("authorization", Matcher::Regex(r"^Bearer .+$".to_string()))
+        .with_status(200)
+        .with_body(
+            serde_json::to_string(&json!({
+                "status": "success",
+                "message": "Subaccount created",
+                "data": {
+                     "id": "837b4e5e-57c8-4e39-b2df-66e7886b8bdb"
+               }
+            }))
+            .unwrap(),
+        )
+        .create_async()
+        .await;
+
+    let config = ChapaConfigBuilder::new()
+        .base_url(server.url())
+        .api_key("test-key")
+        .build()
+        .unwrap();
+    let client = ChapaClient::from_config(config).unwrap();
+
+    let subaccount = CreateSubaccountOptions {
+        account_name: "Abebe Bikila ".to_string(),
+        bank_code: 128,
+        account_number: "0123456789".to_string(),
+        split_type: Some(SplitType::PERCENTAGE),
+        split_value: Some(0.2),
+    };
+    let response = client.create_subaccount(subaccount).await.unwrap();
+
+    assert_eq!(response.status.as_str(), "success");
+    assert!(!response.message.is_null());
+    assert_eq!(response.data.id, "837b4e5e-57c8-4e39-b2df-66e7886b8bdb");
+
+    mock.assert_async().await;
+}

--- a/tests/subaccounts_test.rs
+++ b/tests/subaccounts_test.rs
@@ -45,7 +45,7 @@ async fn test_create_subaccount() {
 
     assert_eq!(response.status.as_str(), "success");
     assert!(!response.message.is_null());
-    assert_eq!(response.data.id, "837b4e5e-57c8-4e39-b2df-66e7886b8bdb");
+    assert!(response.data.is_some());
 
     mock.assert_async().await;
 }

--- a/tests/transaction_test.rs
+++ b/tests/transaction_test.rs
@@ -1,5 +1,7 @@
 use chapa_rust::{
-    client::ChapaClient, config::ChapaConfigBuilder, models::payment::InitializeOptions,
+    client::ChapaClient,
+    config::ChapaConfigBuilder,
+    models::{bank::Currency, payment::InitializeOptions},
 };
 use mockito::{self, Matcher};
 
@@ -55,7 +57,7 @@ async fn test_initialize_transaction() {
 
     let transaction_success = InitializeOptions {
         amount: "100".to_string(),
-        currency: "ETB".to_string(),
+        currency: Currency::ETB,
         email: Some("customer@gmail.com".to_string()),
         first_name: Some("John".to_string()),
         last_name: Some("Doe".to_string()),
@@ -266,7 +268,6 @@ async fn test_cancel_transaction_already_expired() {
 async fn test_get_transaction_events_success() {
     let mut server = mockito::Server::new_async().await;
     let ref_id = "chewatatest-6669";
-
     let success = server
         .mock("GET", format!("/v1/transaction/events/{}", ref_id).as_str())
         .match_header(
@@ -286,13 +287,6 @@ async fn test_get_transaction_events_success() {
                         "type": "log",
                         "created_at": "2024-07-23T07:31:32.000000Z",
                         "updated_at": "2024-07-23T07:31:32.000000Z"
-                    },
-                    {
-                        "item": 23567,
-                        "message": "Transaction is successful with TELEBIRR - RSLT",
-                        "type": "log",
-                        "created_at": "2024-07-23T07:31:55.000000Z",
-                        "updated_at": "2024-07-23T07:31:55.000000Z"
                     },
                     {
                         "item": 24678,
@@ -365,6 +359,133 @@ async fn test_get_transaction_events_failure() {
         .unwrap();
     assert_eq!(response_failure.status, "failed");
     assert!(!response_failure.message.is_null()); // NOTE: check if it is empty because I suspect there might be a change if I put string comparison.
+    assert!(response_failure.data.is_none());
+    failure.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_get_all_transactions_success() {
+    let mut server = mockito::Server::new_async().await;
+
+    let success = server
+        .mock("GET", "/v1/transactions")
+        .match_header(
+            "authorization",
+            Matcher::Regex(r#"^Bearer .+$"#.to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&serde_json::json!({
+                "message": "Transactions retrieved successfully",
+                "status": "success",
+                "data": {
+                    "transactions": [
+                        {
+                            "status": "pending",
+                            "ref_id": "VcEu3Hf55JU",
+                            "type": "Payment Link",
+                            "created_at": "2024-07-27T02:22:46.000000Z",
+                            "currency": "ETB",
+                            "amount": "12.000",
+                            "charge": "0.000",
+                            "trans_id": null,
+                            "payment_method": "card",
+                            "customer": {
+                                "id": 1301688,
+                                "email": null,
+                                "first_name": null,
+                                "last_name": null,
+                                "mobile": null
+                            }
+                        },
+                        {
+                            "status": "pending",
+                            "ref_id": "R6XqfcNVQjW",
+                            "type": "Payment Link",
+                            "created_at": "2024-06-30T04:31:46.000000Z",
+                            "currency": "ETB",
+                            "amount": "12.000",
+                            "charge": "0.000",
+                            "trans_id": null,
+                            "payment_method": "card",
+                            "customer": {
+                                "id": 1145318,
+                                "email": null,
+                                "first_name": null,
+                                "last_name": null,
+                                "mobile": null
+                            }
+                        }
+                    ],
+                    "pagination": {
+                        "per_page": 10,
+                        "current_page": 1,
+                        "first_page_url": "https://api.chapa.co/v1/transactions?page=1",
+                        "next_page_url": "https://api.chapa.co/v1/transactions?page=2",
+                        "prev_page_url": null
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .create_async()
+        .await;
+
+    let config = ChapaConfigBuilder::new()
+        .base_url(server.url())
+        .api_key("CHASECK_TEST-XXXXXXXXXXXXXXX")
+        .build()
+        .unwrap();
+
+    let client = ChapaClient::from_config(config).unwrap();
+    // ACT for success
+    let response_success = client.get_all_transactions().await.unwrap();
+    assert_eq!(response_success.status, "success");
+    assert_eq!(
+        response_success.message,
+        "Transactions retrieved successfully"
+    ); // NOTE: ckeck if it is empty because I suspect there might be a change if I put string comparison.
+    assert!(response_success.data.is_some());
+
+    success.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_get_all_transactions_failure() {
+    let mut server = mockito::Server::new_async().await;
+
+    let failure = server
+        .mock("GET", "/v1/transactions")
+        .match_header(
+            "authorization",
+            Matcher::Regex(r#"^Bearer .+$"#.to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&serde_json::json!({
+                        "message": "Invalid API Key or  the business can't accept payments at the moment. Please verify your API key and ensure the account is active and able to process payments.",
+                        "status": "failed",
+                        "data": null
+            }))
+            .unwrap(),
+        )
+        .create_async()
+        .await;
+
+    let config = ChapaConfigBuilder::new()
+        .base_url(server.url())
+        .api_key("CHASECK_TEST-XXXXXXXXXXXXXXX")
+        .build()
+        .unwrap();
+
+    let client = ChapaClient::from_config(config).unwrap();
+
+    // ACT for failure
+    let response_failure = client.get_all_transactions().await.unwrap();
+    assert_eq!(response_failure.status, "failed");
+    assert!(!response_failure.message.is_null());
     assert!(response_failure.data.is_none());
     failure.assert_async().await;
 }

--- a/tests/transaction_test.rs
+++ b/tests/transaction_test.rs
@@ -1,0 +1,370 @@
+use chapa_rust::{
+    client::ChapaClient, config::ChapaConfigBuilder, models::payment::InitializeOptions,
+};
+use mockito::{self, Matcher};
+
+#[tokio::test]
+async fn test_initialize_transaction() {
+    let mut server = mockito::Server::new_async().await;
+    let success = server
+            .mock("POST", "/v1/transaction/initialize")
+            .match_header(
+                "authorization",
+                Matcher::Regex(r#"^Bearer .+$"#.to_string()),
+            )
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::to_string(&serde_json::json!({
+                "message": "Hosted Link",
+                "status": "success",
+                "data": {
+                    "checkout_url": "https://checkout.chapa.co/checkout/payment/V38JyhpTygC9QimkJrdful9oEjih0heIv53eJ1MsJS6xG"
+                    }
+                }))
+                .unwrap(),
+            )
+            .create_async()
+            .await;
+
+    let failure = server
+        .mock("POST", "/v1/transaction/initialize")
+        .match_header(
+            "authorization",
+            Matcher::Regex(r#"^Bearer .+$"#.to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&serde_json::json!({
+              "message": "Authorization required	",
+              "status": "failed",
+              "data": null
+            }))
+            .unwrap(),
+        )
+        .create_async()
+        .await;
+
+    let config = ChapaConfigBuilder::new()
+        .base_url(server.url())
+        .api_key("CHASECK-xxxxxxxxxxxxxxxx")
+        .build()
+        .unwrap();
+    let mut client = ChapaClient::from_config(config).unwrap();
+
+    let transaction_success = InitializeOptions {
+        amount: "100".to_string(),
+        currency: "ETB".to_string(),
+        email: Some("customer@gmail.com".to_string()),
+        first_name: Some("John".to_string()),
+        last_name: Some("Doe".to_string()),
+        tx_ref: String::from("some_generated_tax_ref"),
+        ..Default::default()
+    };
+    let transaction_failure = InitializeOptions {
+        ..Default::default()
+    };
+
+    // ACT for success
+    let response_success = client
+        .initialize_transaction(transaction_success)
+        .await
+        .unwrap();
+    assert_eq!(response_success.status, "success");
+    assert!(!response_success.message.is_null());
+    assert!(response_success.data.is_some());
+
+    // ACT for failure
+    let response_failure = client
+        .initialize_transaction(transaction_failure)
+        .await
+        .unwrap();
+    assert_eq!(response_failure.status, "failed");
+    assert!(!response_failure.message.is_null());
+    assert!(response_failure.data.is_none());
+
+    success.assert_async().await;
+    failure.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_verify_transaction() {
+    let mut server = mockito::Server::new_async().await;
+    let success = server
+        .mock("GET", "/v1/transaction/verify/chewatatest-6669")
+        .match_header(
+            "authorization",
+            Matcher::Regex(r#"^Bearer .+$"#.to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&serde_json::json!({
+            "message": "Payment details",
+            "status": "success",
+            "data": {
+                "first_name": "Bilen",
+                "last_name": "Gizachew",
+                "email": "abebech_bekele@gmail.com",
+                "currency": "ETB",
+                "amount": 100,
+                "charge": 3.5,
+                "mode": "test",
+                "method": "test",
+                "type": "API",
+                "status": "success",
+                "reference": "6jnheVKQEmy",
+                "tx_ref": "chewatatest-6669",
+                "customization": {
+                    "title": "Payment for my favourite merchant",
+                    "description": "I love online payments",
+                    "logo": null
+                },
+                "meta": null,
+                "created_at": "2023-02-02T07:05:23.000000Z",
+                "updated_at": "2023-02-02T07:05:23.000000Z"
+              }
+            }))
+            .unwrap(),
+        )
+        .create_async()
+        .await;
+
+    let failure = server
+        .mock("GET", "/v1/transaction/verify/chewatatest-6669")
+        .match_header(
+            "authorization",
+            Matcher::Regex(r#"^Bearer .+$"#.to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&serde_json::json!({
+            "message": "Invalid transaction or Transaction not found	",
+            "status": "failed",
+            "data": null
+            }))
+            .unwrap(),
+        )
+        .create_async()
+        .await;
+
+    let config = ChapaConfigBuilder::new()
+        .base_url(server.url())
+        .api_key("CHASECK_TEST-XXXXXXXXXXXXXXX")
+        .build()
+        .unwrap();
+    let mut client = ChapaClient::from_config(config).unwrap();
+
+    // ACT for success
+    let response_success = client.verify_transaction("chewatatest-6669").await.unwrap();
+    assert_eq!(response_success.status, "success");
+    assert!(!response_success.message.is_null()); // NOTE: ckeck if it is empty because I suspect there might be a change if I put string comparison.
+    assert!(response_success.data.is_some());
+
+    // ACT for failure
+    let response_failure = client.verify_transaction("chewatatest-6669").await.unwrap();
+    assert_eq!(response_failure.status, "failed");
+    assert!(!response_failure.message.is_null()); // NOTE: check if it is empty because I suspect there might be a change if I put string comparison.
+    assert!(response_failure.data.is_none());
+
+    success.assert_async().await;
+    failure.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_cancel_transaction_success() {
+    let mut server = mockito::Server::new_async().await;
+    let tx_ref = "tx-456-sdf";
+
+    let success_mock = server
+        .mock("PUT", format!("/v1/transaction/cancel/{}", tx_ref).as_str())
+        .match_header(
+            "authorization",
+            Matcher::Regex(r#"^Bearer .+$"#.to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&serde_json::json!(
+                {
+                    "message": "Checkout link expired successfully",
+                    "status": "success",
+                    "data": {
+                        "tx_ref": "tx-456-sdf",
+                        "amount": 5,
+                        "currency": "ETB",
+                        "created_at": "2025-10-22T09:10:03.000000Z",
+                        "updated_at": "2025-10-22T09:10:21.000000Z"
+                    }
+                }
+            ))
+            .unwrap(),
+        )
+        .create_async()
+        .await;
+
+    let config = ChapaConfigBuilder::new()
+        .base_url(server.url())
+        .api_key("CHASECK-xxxxxxxxxxxxxxxx")
+        .build()
+        .unwrap();
+    let client = ChapaClient::from_config(config).unwrap();
+    let response = client.cancel_transaction(tx_ref).await.unwrap();
+    assert_eq!(response.status, "success");
+    assert_eq!(response.message, "Checkout link expired successfully");
+    assert!(response.data.is_some());
+
+    let data = response.data.unwrap();
+    assert_eq!(data.tx_ref, tx_ref);
+    assert_eq!(data.amount, 5.0);
+    assert_eq!(data.currency.as_str(), "ETB");
+
+    success_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_cancel_transaction_already_expired() {
+    let mut server = mockito::Server::new_async().await;
+    let tx_ref = "already-expired-ref";
+    let failure_mock = server
+        .mock("PUT", format!("/v1/transaction/cancel/{}", tx_ref).as_str())
+        .match_header(
+            "authorization",
+            Matcher::Regex(r#"^Bearer .+$"#.to_string()),
+        )
+        .with_status(200)
+        .match_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&serde_json::json!({
+                "message": "Payment link already expired",
+                "status": "failed",
+                "data": null
+            }))
+            .unwrap(),
+        )
+        .create_async()
+        .await;
+
+    let config = ChapaConfigBuilder::new()
+        .base_url(server.url())
+        .api_key("CHASECK-xxxxxxxxxxxxxxxx")
+        .build()
+        .unwrap();
+    let client = ChapaClient::from_config(config).unwrap();
+
+    let response = client.cancel_transaction(tx_ref).await.unwrap();
+    assert_eq!(response.status, "failed");
+    assert_eq!(response.message, "Payment link already expired");
+    assert!(response.data.is_none());
+
+    failure_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_get_transaction_events_success() {
+    let mut server = mockito::Server::new_async().await;
+    let ref_id = "chewatatest-6669";
+
+    let success = server
+        .mock("GET", format!("/v1/transaction/events/{}", ref_id).as_str())
+        .match_header(
+            "authorization",
+            Matcher::Regex(r#"^Bearer .+$"#.to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&serde_json::json!({
+                "message": "Transaction events fetched",
+                "status": "success",
+                "data": [
+                    {
+                        "item": 23445,
+                        "message": "Attempted to make payment with telebirr USSD",
+                        "type": "log",
+                        "created_at": "2024-07-23T07:31:32.000000Z",
+                        "updated_at": "2024-07-23T07:31:32.000000Z"
+                    },
+                    {
+                        "item": 23567,
+                        "message": "Transaction is successful with TELEBIRR - RSLT",
+                        "type": "log",
+                        "created_at": "2024-07-23T07:31:55.000000Z",
+                        "updated_at": "2024-07-23T07:31:55.000000Z"
+                    },
+                    {
+                        "item": 24678,
+                        "message": "Redirecting to confirmation page",
+                        "type": "log",
+                        "created_at": "2024-07-23T07:31:32.000000Z",
+                        "updated_at": "2024-07-23T07:31:32.000000Z"
+                    }
+                ]
+            }))
+            .unwrap(),
+        )
+        .create_async()
+        .await;
+    let config = ChapaConfigBuilder::new()
+        .base_url(server.url())
+        .api_key("CHASECK_TEST-XXXXXXXXXXXXXXX")
+        .build()
+        .unwrap();
+
+    let client = ChapaClient::from_config(config).unwrap();
+
+    // ACT for success
+    let response_success = client
+        .get_transaction_events("chewatatest-6669")
+        .await
+        .unwrap();
+    assert_eq!(response_success.status, "success");
+    assert!(!response_success.message.is_null()); // NOTE: ckeck if it is empty because I suspect there might be a change if I put string comparison.
+    assert!(response_success.data.is_some());
+
+    success.assert_async().await;
+}
+#[tokio::test]
+async fn test_get_transaction_events_failure() {
+    let mut server = mockito::Server::new_async().await;
+    let ref_id = "chewatatest-6669";
+
+    let failure = server
+        .mock("GET", format!("/v1/transaction/events/{}", ref_id).as_str())
+        .match_header(
+            "authorization",
+            Matcher::Regex(r#"^Bearer .+$"#.to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&serde_json::json!({
+                "message": "Transaction not found",
+                "status": "failed",
+                "data": null
+            }))
+            .unwrap(),
+        )
+        .create_async()
+        .await;
+
+    let config = ChapaConfigBuilder::new()
+        .base_url(server.url())
+        .api_key("CHASECK_TEST-XXXXXXXXXXXXXXX")
+        .build()
+        .unwrap();
+
+    let client = ChapaClient::from_config(config).unwrap();
+
+    // ACT for failure
+    let response_failure = client
+        .get_transaction_events("chewatatest-6669")
+        .await
+        .unwrap();
+    assert_eq!(response_failure.status, "failed");
+    assert!(!response_failure.message.is_null()); // NOTE: check if it is empty because I suspect there might be a change if I put string comparison.
+    assert!(response_failure.data.is_none());
+    failure.assert_async().await;
+}

--- a/tests/transfer_test.rs
+++ b/tests/transfer_test.rs
@@ -15,39 +15,56 @@ async fn test_get_all_transfers_no_filters() {
         .with_header("content-type", "application/json")
         .with_body(
             serde_json::to_string(&serde_json::json!({
-                "message": "Transfer details fetched",
-                "status": "success",
-                "pagination": {
-                    "current_page": 1,
-                    "first_page_url": "https://api.chapa.co/v1/transfers?page=1",
-                    "last_page": 16,
-                    "last_page_url": "https://api.chapa.co/v1/transfers?page=16",
-                    "next_page_url": "https://api.chapa.co/v1/transfers?page=2",
-                    "path": "https://api.chapa.co/v1/transfers?page=1",
-                    "per_page": 10,
-                    "prev_page_url": null,
-                    "to": 10,
-                    "total": 159,
-                    "error": []
-                },
-                "data": [
-                    {
-                        "account_name": "suz",
-                        "account_number": "1",
-                        "currency": "ETB",
-                        "amount": 1,
-                        "charge": 0,
-                        "transfer_type": "bank",
-                        "chapa_reference": "7039636674388",
-                        "bank_code": 656,
-                        "bank_name": "Awash Bank",
-                        "bank_reference": null,
-                        "status": "failed/cancelled",
-                        "reference": "7039636674388",
-                        "created_at": "2022-10-24T14:48:06.000000Z",
-                        "updated_at": "2023-10-10T09:20:27.000000Z"
-                    }
-                ]
+
+              "message": "Transfer details fetched",
+              "status": "success",
+              "meta": {
+                  "current_page": 1,
+                  "first_page_url": "https://api.chapa.co/v1/transfers?page=1",
+                  "last_page": 16,
+                  "last_page_url": "https://api.chapa.co/v1/transfers?page=16",
+                  "next_page_url": "https://api.chapa.co/v1/transfers?page=2",
+                  "path": "https://api.chapa.co/v1/transfers?page=1",
+                  "per_page": 10,
+                  "prev_page_url": null,
+                  "to": 10,
+                  "total": 159,
+                  "error": []
+              },
+              "data": [
+                  {
+                      "account_name": "suz",
+                      "account_number": "1",
+                      "currency": "ETB",
+                      "amount": 1,
+                      "charge": 0,
+                      "transfer_type": "bank",
+                      "chapa_reference": "7039636706566",
+                      "bank_code": 656,
+                      "bank_name": "Awash Bank",
+                      "bank_reference": null,
+                      "status": "failed/cancelled",
+                      "reference": null,
+                      "created_at": "2022-10-24T14:46:56.000000Z",
+                      "updated_at": "2023-08-07T10:49:59.000000Z"
+                  },
+                  {
+                      "account_name": "Tamiru",
+                      "account_number": "1000089352731",
+                      "currency": "ETB",
+                      "amount": 5,
+                      "charge": 0,
+                      "transfer_type": "bank",
+                      "chapa_reference": "FFY5w8lEYRU",
+                      "bank_code": 893,
+                      "bank_name": "Cooperative Bank of Oromia (COOP)",
+                      "bank_reference": null,
+                      "status": "failed/cancelled",
+                      "reference": "FFY5w8lEYRU",
+                      "created_at": "2023-05-24T13:48:42.000000Z",
+                      "updated_at": "2023-10-10T09:21:27.000000Z"
+                  }
+              ]
             }))
             .unwrap(),
         )
@@ -66,8 +83,8 @@ async fn test_get_all_transfers_no_filters() {
         .await
         .unwrap();
     assert_eq!(response.status, "success");
-    assert!(response.message.is_null());
-    assert!(response.data.is_none());
+    assert_eq!(response.message, "Transfer details fetched");
+    assert!(response.data.is_some());
     mock.assert_async().await;
 }
 
@@ -160,7 +177,7 @@ async fn test_get_all_transfers_with_filters() {
         .await
         .unwrap();
     assert_eq!(response.status, "success");
-    assert!(!response.message.is_null());
+    assert!(!response.message.is_empty());
     assert!(response.data.is_some());
     mock.assert_async().await;
 }

--- a/tests/transfer_test.rs
+++ b/tests/transfer_test.rs
@@ -1,0 +1,168 @@
+use chapa_rust::{client::ChapaClient, config::ChapaConfigBuilder};
+use mockito::{self, Matcher};
+
+#[tokio::test]
+async fn test_get_all_transfers_no_filters() {
+    let mut server = mockito::Server::new_async().await;
+
+    let mock = server
+        .mock("GET", "/v1/transfers")
+        .match_header(
+            "authorization",
+            Matcher::Regex(r#"^Bearer .+$"#.to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&serde_json::json!({
+                "message": "Transfer details fetched",
+                "status": "success",
+                "pagination": {
+                    "current_page": 1,
+                    "first_page_url": "https://api.chapa.co/v1/transfers?page=1",
+                    "last_page": 16,
+                    "last_page_url": "https://api.chapa.co/v1/transfers?page=16",
+                    "next_page_url": "https://api.chapa.co/v1/transfers?page=2",
+                    "path": "https://api.chapa.co/v1/transfers?page=1",
+                    "per_page": 10,
+                    "prev_page_url": null,
+                    "to": 10,
+                    "total": 159,
+                    "error": []
+                },
+                "data": [
+                    {
+                        "account_name": "suz",
+                        "account_number": "1",
+                        "currency": "ETB",
+                        "amount": 1,
+                        "charge": 0,
+                        "transfer_type": "bank",
+                        "chapa_reference": "7039636674388",
+                        "bank_code": 656,
+                        "bank_name": "Awash Bank",
+                        "bank_reference": null,
+                        "status": "failed/cancelled",
+                        "reference": "7039636674388",
+                        "created_at": "2022-10-24T14:48:06.000000Z",
+                        "updated_at": "2023-10-10T09:20:27.000000Z"
+                    }
+                ]
+            }))
+            .unwrap(),
+        )
+        .create_async()
+        .await;
+
+    let config = ChapaConfigBuilder::new()
+        .base_url(server.url())
+        .api_key("CHASECK-xxxxxxxxxxxxxxxx")
+        .build()
+        .unwrap();
+    let client = ChapaClient::from_config(config).unwrap();
+
+    let response = client
+        .get_all_transfers(None, None, None, None)
+        .await
+        .unwrap();
+    assert_eq!(response.status, "success");
+    assert!(response.message.is_null());
+    assert!(response.data.is_none());
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_get_all_transfers_with_filters() {
+    let mut server = mockito::Server::new_async().await;
+
+    let mock = server
+        .mock(
+            "GET",
+            "/v1/transfers?from_date=2025-01-01&to_date=2025-01-31&currency=ETB&status=success",
+        )
+        .match_header(
+            "authorization",
+            Matcher::Regex(r#"^Bearer .+$"#.to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::to_string(&serde_json::json!({
+                "message": "Transfer details fetched",
+                "status": "success",
+                "meta": {
+                    "current_page": 1,
+                    "first_page_url": "https://api.chapa.co/v1/transfers?page=1",
+                    "last_page": 16,
+                    "last_page_url": "https://api.chapa.co/v1/transfers?page=16",
+                    "next_page_url": "https://api.chapa.co/v1/transfers?page=2",
+                    "path": "https://api.chapa.co/v1/transfers?page=1",
+                    "per_page": 10,
+                    "prev_page_url": null,
+                    "to": 10,
+                    "total": 159,
+                    "error": []
+                },
+                "data": [
+                    {
+                        "account_name": "suz",
+                        "account_number": "1",
+                        "currency": "ETB",
+                        "amount": 1,
+                        "charge": 0,
+                        "transfer_type": "bank",
+                        "chapa_reference": "7039636706566",
+                        "bank_code": 656,
+                        "bank_name": "Awash Bank",
+                        "bank_reference": null,
+                        "status": "failed/cancelled",
+                        "reference": null,
+                        "created_at": "2022-10-24T14:46:56.000000Z",
+                        "updated_at": "2023-08-07T10:49:59.000000Z"
+                    },
+                    {
+                        "account_name": "suz",
+                        "account_number": "1",
+                        "currency": "ETB",
+                        "amount": 1,
+                        "charge": 0,
+                        "transfer_type": "bank",
+                        "chapa_reference": "7039636674388",
+                        "bank_code": 656,
+                        "bank_name": "Awash Bank",
+                        "bank_reference": null,
+                        "status": "failed/cancelled",
+                        "reference": "7039636674388",
+                        "created_at": "2022-10-24T14:48:06.000000Z",
+                        "updated_at": "2023-10-10T09:20:27.000000Z"
+                    }
+                ]
+            }))
+            .unwrap(),
+        )
+        .create_async()
+        .await;
+
+    let config = ChapaConfigBuilder::new()
+        .base_url(server.url())
+        .api_key("CHASECK-xxxxxxxxxxxxxxxx")
+        .build()
+        .unwrap();
+    let client = ChapaClient::from_config(config).unwrap();
+
+    let response = client
+        .get_all_transfers(
+            Some("2025-01-01"),
+            Some("2025-01-31"),
+            Some("ETB"),
+            Some("success"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status, "success");
+    assert!(!response.message.is_null());
+    assert!(response.data.is_some());
+    mock.assert_async().await;
+}
+#[tokio::test]
+async fn test_bulk_transfers() {}


### PR DESCRIPTION
# Pull Request

Short description
- What:  finish the missing parts of the chapa-rust SDK
- Why: I was building Distributed SMS  to manage every school in the country, and for schools that are private and request payment. i need payment gateway that can handle this but this sdk is missing a lot if features so implement the missing parts of the SDK specifically for my use case 
- How: extend `ChapaClient` for supporting all the endpoints 

Checklist
- [+] PR targets the correct branch <!-- i.e., develop -->
- [+] Code compiles without errors
- [+] Tests added/updated or not applicable
- [+] CI passes
- [+] Docs/CHANGELOG updated if needed
- [+] PR follows Conventional Commits (feat:, fix:, docs:, etc.)

Testing
- Run: `make check`
considered to use `cargo-nextest` this is the best test experience for Rust, specifically because it enables high-performance, parallel test execution by running each test in a separate process 
<img width="1280" height="1024" alt="Screenshot (208)" src="https://github.com/user-attachments/assets/00c52ba1-55f6-4246-a019-9ac436a6797a" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds multiple new API endpoints and refactors request handling (including a breaking change from `currency: String` to `Currency` enum), which may impact existing consumers and request serialization behavior.
> 
> **Overview**
> Expands the SDK’s coverage by adding client support for **transactions** (`cancel_transaction`, `get_transaction_events`, `get_all_transactions`), **transfers** (`initiate_transfer`, `verify_transfer`, `bulk_transfer`, `get_all_transfers` with query filters), and **balances** (`get_balances`, `get_balance_by_currency`, `swap_currency`).
> 
> Refactors the internal request helper to support multiple body encodings via `RequestBody` (`None`/`Json`/`Form`), introduces new models for balances, transfers, transaction events/cancelation, and standardizes currency handling by switching `InitializeOptions.currency` to the `Currency` enum (also used across new APIs).
> 
> Moves inline client tests into a dedicated `tests/` harness (wired via `Cargo.toml`), adds new mockito-based coverage for the new endpoints, and updates examples/README snippets to use `Currency`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00e7d7e5c9b8d812e964a1c4d07d56c0355f37c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->